### PR TITLE
Add support for system adapter execution modes and JSON-RPC dispatching

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ To benchmark a new platform, implement the adapter interface:
 
 - **stdio transport**: use `--system-adapter-stdio-cmd` (spicebench starts the child process).
 - **HTTP transport**: use `--system-adapter-http-url` (spicebench connects to a remote adapter endpoint).
+- **execution mode**: use `--system-adapter-execution-mode`:
+    - `adapter-command` (default): dispatches `spicebench run ...` to adapter JSON-RPC `run.load`
+    - `direct-query`: spicebench runs load/query path directly, while still connecting to adapter
+
+When adapter transport is configured, `spicebench run ...` is dispatched to spidapter method `run.load` over JSON-RPC and the adapter's `stdout`/`stderr` are streamed back.
 
 #### Stdio example (child process started by spicebench)
 
@@ -202,7 +207,18 @@ Notes:
 - Set **exactly one** of `--system-adapter-stdio-cmd` or `--system-adapter-http-url`.
 - `--system-adapter-stdio-args` passes CLI args to the stdio adapter command.
 - `--system-adapter-env` is only valid for stdio transport.
-- On connection, spicebench issues JSON-RPC `rpc.methods` to verify the adapter is reachable.
+- Spicebench validates the adapter supports JSON-RPC method `run.load` before dispatch.
+
+#### Direct-query example (run in spicebench, keep adapter connected)
+
+```bash
+spicebench run \
+    --query-set tpch \
+    --spicepod-path ./spicepod.yaml \
+    --system-adapter-name spidapter \
+    --system-adapter-execution-mode direct-query \
+    --system-adapter-http-url http://127.0.0.1:8080/jsonrpc
+```
 
 ## License
 

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -16,7 +16,7 @@ limitations under the License.
 
 use std::path::PathBuf;
 
-use clap::{ArgAction, Parser, Subcommand};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 
 mod dataset;
 pub use dataset::{DatasetTestArgs, LoadTestArgs};
@@ -82,6 +82,12 @@ pub struct CommonArgs {
     #[arg(long, default_value = "system_adapter")]
     pub(crate) system_adapter_name: String,
 
+    /// How to execute when a system adapter transport is configured.
+    /// - adapter-command: dispatch spicebench run as a JSON-RPC command (e.g. run.load)
+    /// - direct-query: execute load/query path in spicebench directly
+    #[arg(long, value_enum, default_value = "adapter-command")]
+    pub(crate) system_adapter_execution_mode: SystemAdapterExecutionMode,
+
     /// Command to run for a stdio JSON-RPC system adapter.
     #[arg(long, conflicts_with = "system_adapter_http_url")]
     pub(crate) system_adapter_stdio_cmd: Option<String>,
@@ -123,4 +129,10 @@ fn parse_key_val(s: &str) -> Result<(String, String), String> {
         .find('=')
         .ok_or_else(|| "expected KEY=VALUE formatted header".to_string())?;
     Ok((s[..pos].to_string(), s[pos + 1..].to_string()))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum SystemAdapterExecutionMode {
+    AdapterCommand,
+    DirectQuery,
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{collections::{BTreeMap, HashMap}, sync::Arc, time::Duration};
 
-use crate::args::{CommonArgs, DatasetTestArgs};
+use crate::args::{CommonArgs, DatasetTestArgs, SystemAdapterExecutionMode};
 use test_framework::{
     anyhow,
     app::{App, AppBuilder},
@@ -30,7 +30,7 @@ use test_framework::{
 };
 use tokio::{
     io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
-    process::{ChildStdin, ChildStdout, Command},
+    process::{Child, ChildStdin, ChildStdout, Command},
 };
 
 #[cfg(feature = "append")]
@@ -103,16 +103,6 @@ pub(crate) async fn build_test_with_validation(
 pub(crate) async fn run_or_connect_spiced(
     args: &CommonArgs,
 ) -> anyhow::Result<(App, SpicedInstance)> {
-    if let Some(mut adapter) = SystemAdapterClient::connect(args).await? {
-        let methods = adapter.rpc_methods().await?;
-        println!(
-            "Connected to system adapter '{}' via {} ({} methods)",
-            args.system_adapter_name,
-            adapter.transport_name(),
-            methods.len()
-        );
-    }
-
     let (app, mut instance) = if args.is_external_instance() {
         println!(
             "Connecting to external spiced instance at: {}",
@@ -171,8 +161,153 @@ pub(crate) async fn get_app_and_start_request(
     Ok((app, start_request))
 }
 
+pub(crate) async fn maybe_dispatch_run_to_system_adapter(
+    raw_cli_args: &[String],
+    common_args: &CommonArgs,
+) -> anyhow::Result<bool> {
+    if !has_system_adapter_transport(common_args) {
+        return Ok(false);
+    }
+
+    let mut adapter = SystemAdapterClient::connect(common_args)
+        .await?
+        .context("System adapter transport was configured but could not be initialized")?;
+
+    let methods = adapter.rpc_methods().await?;
+
+    if common_args.system_adapter_execution_mode == SystemAdapterExecutionMode::DirectQuery {
+        println!(
+            "Connected to system adapter '{}' via {} in direct-query mode (spicebench executes query/load path directly)",
+            common_args.system_adapter_name,
+            adapter.transport_name(),
+        );
+        return Ok(false);
+    }
+
+    let Some(method) = resolve_system_adapter_method(raw_cli_args) else {
+        anyhow::bail!(
+            "No JSON-RPC adapter method mapping for current command invocation: {:?}",
+            raw_cli_args
+        );
+    };
+
+    if !methods.iter().any(|available| available == method) {
+        anyhow::bail!(
+            "System adapter '{}' via {} does not support required method '{method}'",
+            common_args.system_adapter_name,
+            adapter.transport_name(),
+        );
+    }
+
+    let adapter_args = adapter_cli_args_for_run(raw_cli_args);
+    let mut params = serde_json::Map::new();
+    params.insert("args".to_string(), serde_json::to_value(adapter_args)?);
+
+    for (key, value) in &common_args.system_adapter_param {
+        params.insert(key.clone(), serde_json::Value::String(value.clone()));
+    }
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": method,
+        "params": serde_json::Value::Object(params),
+    });
+
+    let response = adapter.call(request).await?;
+    handle_adapter_execution_response(&response)?;
+
+    Ok(true)
+}
+
+fn resolve_system_adapter_method(raw_cli_args: &[String]) -> Option<&'static str> {
+    match raw_cli_args.first().map(String::as_str) {
+        Some("run") => Some("run.load"),
+        _ => None,
+    }
+}
+
+fn has_system_adapter_transport(args: &CommonArgs) -> bool {
+    args.system_adapter_stdio_cmd.is_some() || args.system_adapter_http_url.is_some()
+}
+
+fn adapter_cli_args_for_run(raw_cli_args: &[String]) -> Vec<String> {
+    let mut filtered = Vec::new();
+    let mut skip_next = false;
+
+    for (index, arg) in raw_cli_args.iter().enumerate() {
+        if index == 0 && arg == "run" {
+            continue;
+        }
+
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+
+        let takes_value = [
+            "--system-adapter-name",
+            "--system-adapter-execution-mode",
+            "--system-adapter-stdio-cmd",
+            "--system-adapter-stdio-args",
+            "--system-adapter-http-url",
+            "--system-adapter-param",
+            "--system-adapter-env",
+        ];
+
+        if takes_value.contains(&arg.as_str()) {
+            skip_next = true;
+            continue;
+        }
+
+        if takes_value.iter().any(|flag| arg.starts_with(&format!("{flag}="))) {
+            continue;
+        }
+
+        filtered.push(arg.clone());
+    }
+
+    filtered
+}
+
+fn handle_adapter_execution_response(response: &serde_json::Value) -> anyhow::Result<()> {
+    let result = response
+        .get("result")
+        .context("System adapter response missing JSON-RPC result payload")?;
+
+    if let Some(stdout) = result.get("stdout").and_then(|v| v.as_str())
+        && !stdout.is_empty()
+    {
+        print!("{stdout}");
+    }
+
+    if let Some(stderr) = result.get("stderr").and_then(|v| v.as_str())
+        && !stderr.is_empty()
+    {
+        eprint!("{stderr}");
+    }
+
+    let success = result
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let exit_code = result
+        .get("exit_code")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(1);
+
+    if !success || exit_code != 0 {
+        anyhow::bail!(
+            "System adapter command failed (success={success}, exit_code={exit_code})"
+        );
+    }
+
+    Ok(())
+}
+
 enum SystemAdapterClient {
     Stdio {
+        child: Child,
         stdin: ChildStdin,
         stdout: BufReader<ChildStdout>,
     },
@@ -239,9 +374,8 @@ impl SystemAdapterClient {
                 .take()
                 .context("System adapter stdio child missing stdout")?;
 
-            std::mem::forget(child);
-
             return Ok(Some(Self::Stdio {
+                child,
                 stdin,
                 stdout: BufReader::new(stdout),
             }));
@@ -284,7 +418,11 @@ impl SystemAdapterClient {
 
     async fn call(&mut self, request: serde_json::Value) -> anyhow::Result<serde_json::Value> {
         match self {
-            Self::Stdio { stdin, stdout } => {
+            Self::Stdio {
+                child: _,
+                stdin,
+                stdout,
+            } => {
                 let payload = serde_json::to_string(&request)?;
                 stdin.write_all(payload.as_bytes()).await?;
                 stdin.write_all(b"\n").await?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::{collections::{BTreeMap, HashMap}, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
 use crate::args::{CommonArgs, DatasetTestArgs, SystemAdapterExecutionMode};
 use test_framework::{
@@ -260,7 +264,10 @@ fn adapter_cli_args_for_run(raw_cli_args: &[String]) -> Vec<String> {
             continue;
         }
 
-        if takes_value.iter().any(|flag| arg.starts_with(&format!("{flag}="))) {
+        if takes_value
+            .iter()
+            .any(|flag| arg.starts_with(&format!("{flag}=")))
+        {
             continue;
         }
 
@@ -297,9 +304,7 @@ fn handle_adapter_execution_response(response: &serde_json::Value) -> anyhow::Re
         .unwrap_or(1);
 
     if !success || exit_code != 0 {
-        anyhow::bail!(
-            "System adapter command failed (success={success}, exit_code={exit_code})"
-        );
+        anyhow::bail!("System adapter command failed (success={success}, exit_code={exit_code})");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,19 @@ async fn main() -> anyhow::Result<()> {
     let _ = rustls::crypto::CryptoProvider::install_default(
         rustls::crypto::aws_lc_rs::default_provider(),
     );
+    let raw_cli_args: Vec<String> = std::env::args().skip(1).collect();
     let cli = Cli::parse();
 
     match cli.subcommand {
-        Commands::Run(args) => commands::load::run(&args).await?,
+        Commands::Run(args) => {
+            if commands::maybe_dispatch_run_to_system_adapter(&raw_cli_args, &args.test_args.common)
+                .await?
+            {
+                return Ok(());
+            }
+
+            commands::load::run(&args).await?
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This pull request introduces a new execution mode for system adapters, allowing for more flexible benchmarking workflows in `spicebench`. The changes add support for both dispatching commands to adapters via JSON-RPC and executing load/query paths directly within `spicebench` while maintaining adapter connectivity. The implementation includes new CLI options, updated documentation, and logic to handle the two execution modes.

**Adapter execution modes and CLI enhancements:**

* Added a new `--system-adapter-execution-mode` CLI argument (with `adapter-command` and `direct-query` options) to `CommonArgs`, and documented its usage in `README.md`. [[1]](diffhunk://#diff-c5354523dab7ee14c84278715c952cb7e302af46f5c8372b94375b36f003b93eR85-R90) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R175-R179) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L205-R221)
* Introduced the `SystemAdapterExecutionMode` enum to represent execution modes and integrated it into argument parsing.

**Core logic and dispatch improvements:**

* Implemented `maybe_dispatch_run_to_system_adapter` to decide whether to dispatch the `run` command to the adapter via JSON-RPC or execute directly, including method resolution, argument filtering, and response handling.
* Updated the main entrypoint in `src/main.rs` to use the new dispatch logic, ensuring correct execution flow based on the selected adapter mode.

**System adapter client and transport changes:**

* Modified `SystemAdapterClient` to retain the child process and handle both execution modes, updating the transport logic and response handling accordingly. [[1]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL242-R383) [[2]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdL287-R430)

These changes improve the flexibility and robustness of system adapter integration in `spicebench`, making it easier to benchmark new platforms and adapt workflows as needed.