### PR TITLE
refactor: Make Dataset trait more robust for returning specific table batches and metadata

### DIFF
--- a/crates/data-generation/src/dataset/mod.rs
+++ b/crates/data-generation/src/dataset/mod.rs
@@ -15,8 +15,23 @@ limitations under the License.
 */
 
 pub mod tpch;
+pub mod simple_sequence;
+
+use std::sync::Arc;
 
 use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
+
+/// Metadata about a table in a dataset.
+#[derive(Debug, Clone)]
+pub struct DatasetTable {
+    /// The name of the table.
+    pub name: String,
+    /// The Arrow schema for the table.
+    pub schema: SchemaRef,
+    /// The time column for the table, if any.
+    pub time_column: Option<String>,
+}
 
 /// A batch of data from a dataset, tagged with its table name.
 pub struct DatasetBatch {
@@ -25,26 +40,72 @@ pub struct DatasetBatch {
 }
 
 pub trait Dataset: Send {
-    /// Returns the next batch of data, or `None` if exhausted.
-    fn next_batch(&mut self) -> anyhow::Result<Option<DatasetBatch>>;
+    /// Returns the next raw batch of data for the given table, or `None` if exhausted.
+    ///
+    /// Most callers should use [`next_batch`]
+    /// instead, which validates the table name and output schema.
+    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>>;
 
-    /// Returns the list of table names this dataset produces.
-    fn tables(&self) -> Vec<String>;
+    /// Returns the next batch of data for the given table, or `None` if exhausted.
+    ///
+    /// Validates that `table` is a known table for this dataset, delegates to
+    /// [`raw_next_batch`], and verifies the returned batch matches the expected schema.
+    fn next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+        let tables = self.tables();
+        let dataset_table = tables
+            .iter()
+            .find(|t| t.name == table)
+            .ok_or_else(|| anyhow::anyhow!("Unknown table: {table}"))?;
+        let expected_schema = Arc::clone(&dataset_table.schema);
 
-    /// Returns the time column name for the given table, if any.
-    fn time_column(&self, table: &str) -> Option<String>;
+        let Some(batch) = self.raw_next_batch(table)? else {
+            return Ok(None);
+        };
+
+        if batch.batch.schema() != expected_schema {
+            anyhow::bail!(
+                "Schema mismatch for table '{table}': expected {expected_schema}, got {}",
+                batch.batch.schema()
+            );
+        }
+
+        Ok(Some(batch))
+    }
+
+    /// Returns a batch for every table. Returns `None` if all tables are exhausted.
+    fn next_batches(&mut self) -> anyhow::Result<Option<Vec<DatasetBatch>>> {
+        let tables = self.tables();
+        let mut batches = Vec::new();
+        for table in &tables {
+            if let Some(batch) = self.next_batch(&table.name)? {
+                batches.push(batch);
+            }
+        }
+        if batches.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(batches))
+        }
+    }
+
+    /// Returns the list of tables this dataset produces, including metadata.
+    fn tables(&self) -> Vec<DatasetTable>;
 }
 
 impl Dataset for Box<dyn Dataset> {
-    fn next_batch(&mut self) -> anyhow::Result<Option<DatasetBatch>> {
-        (**self).next_batch()
+    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+        (**self).raw_next_batch(table)
     }
 
-    fn tables(&self) -> Vec<String> {
+    fn next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+        (**self).next_batch(table)
+    }
+
+    fn next_batches(&mut self) -> anyhow::Result<Option<Vec<DatasetBatch>>> {
+        (**self).next_batches()
+    }
+
+    fn tables(&self) -> Vec<DatasetTable> {
         (**self).tables()
-    }
-
-    fn time_column(&self, table: &str) -> Option<String> {
-        (**self).time_column(table)
     }
 }

--- a/crates/data-generation/src/dataset/simple_sequence.rs
+++ b/crates/data-generation/src/dataset/simple_sequence.rs
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use arrow::array::{Int64Array, RecordBatch, TimestampMicrosecondArray};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+
+use crate::config::DatasetConfig;
+
+use super::{Dataset, DatasetBatch, DatasetTable};
+
+/// A simple dataset that generates a sequence of integers in a single table.
+///
+/// Each call to `raw_next_batch` returns `batch_size` rows with sequential `id`
+/// and `value = id * 10`. After `num_steps` batches the dataset is exhausted.
+pub struct SimpleSequenceDataset {
+    batch_size: usize,
+    current_offset: i64,
+    remaining_steps: u16,
+}
+
+impl SimpleSequenceDataset {
+    pub fn new(config: &DatasetConfig) -> Self {
+        let batch_size = (config.scale_factor * 1000.0) as usize;
+        Self {
+            batch_size,
+            current_offset: 0,
+            remaining_steps: config.num_steps,
+        }
+    }
+
+    /// Returns the static Arrow schema for the `integer_sequence` table.
+    pub fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("value", DataType::Int64, false),
+            Field::new(
+                "inserted_at",
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                true,
+            ),
+        ]))
+    }
+}
+
+impl Dataset for SimpleSequenceDataset {
+    fn raw_next_batch(&mut self, _table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+        if self.remaining_steps == 0 {
+            return Ok(None);
+        }
+        self.remaining_steps -= 1;
+
+        let now_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before UNIX epoch")
+            .as_micros() as i64;
+
+        let ids: Int64Array = (self.current_offset..self.current_offset + self.batch_size as i64)
+            .collect();
+        let values: Int64Array = (self.current_offset..self.current_offset + self.batch_size as i64)
+            .map(|id| id * 10)
+            .collect();
+        let timestamps = TimestampMicrosecondArray::from(vec![Some(now_us); self.batch_size])
+            .with_timezone("UTC");
+
+        self.current_offset += self.batch_size as i64;
+
+        let batch = RecordBatch::try_new(
+            Self::schema(),
+            vec![Arc::new(ids), Arc::new(values), Arc::new(timestamps)],
+        )?;
+
+        Ok(Some(DatasetBatch {
+            table_name: "integer_sequence".to_string(),
+            batch,
+        }))
+    }
+
+    fn tables(&self) -> Vec<DatasetTable> {
+        vec![DatasetTable {
+            name: "integer_sequence".to_string(),
+            schema: Self::schema(),
+            time_column: Some("inserted_at".to_string()),
+        }]
+    }
+}

--- a/crates/data-generation/src/dataset/tpch.rs
+++ b/crates/data-generation/src/dataset/tpch.rs
@@ -14,16 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashSet;
+use std::sync::Arc;
+
 use arrow::array::RecordBatch;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use duckdb::Connection;
 use tracing::info;
 
 use crate::config::DatasetConfig;
 
-use super::{Dataset, DatasetBatch};
+use super::{Dataset, DatasetBatch, DatasetTable};
 
-/// TPC-H tables with their corresponding time column names.
-/// Matches the convention in `test-framework/src/queries/mod.rs`.
+/// TPC-H table definitions: (table_name, time_column, schema_fn).
 const TPCH_TABLE_TIME_COLUMNS: &[(&str, &str)] = &[
     ("region", "r_created_at"),
     ("nation", "n_created_at"),
@@ -34,6 +37,100 @@ const TPCH_TABLE_TIME_COLUMNS: &[(&str, &str)] = &[
     ("orders", "o_created_at"),
     ("lineitem", "l_created_at"),
 ];
+
+/// Returns the static Arrow schema for a TPC-H table (including the appended time column).
+fn tpch_schema(table: &str, time_col: &str) -> SchemaRef {
+    let ts = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+    let fields: Vec<Field> = match table {
+        "region" => vec![
+            Field::new("r_regionkey", DataType::Int32, false),
+            Field::new("r_name", DataType::Utf8, false),
+            Field::new("r_comment", DataType::Utf8, true),
+            Field::new(time_col, ts, true),
+        ],
+        "nation" => vec![
+            Field::new("n_nationkey", DataType::Int32, false),
+            Field::new("n_name", DataType::Utf8, false),
+            Field::new("n_regionkey", DataType::Int32, false),
+            Field::new("n_comment", DataType::Utf8, true),
+            Field::new(time_col, ts, true),
+        ],
+        "supplier" => vec![
+            Field::new("s_suppkey", DataType::Int32, false),
+            Field::new("s_name", DataType::Utf8, false),
+            Field::new("s_address", DataType::Utf8, false),
+            Field::new("s_nationkey", DataType::Int32, false),
+            Field::new("s_phone", DataType::Utf8, false),
+            Field::new("s_acctbal", DataType::Decimal128(15, 2), false),
+            Field::new("s_comment", DataType::Utf8, true),
+            Field::new(time_col, ts, true),
+        ],
+        "customer" => vec![
+            Field::new("c_custkey", DataType::Int32, false),
+            Field::new("c_name", DataType::Utf8, false),
+            Field::new("c_address", DataType::Utf8, false),
+            Field::new("c_nationkey", DataType::Int32, false),
+            Field::new("c_phone", DataType::Utf8, false),
+            Field::new("c_acctbal", DataType::Decimal128(15, 2), false),
+            Field::new("c_mktsegment", DataType::Utf8, false),
+            Field::new("c_comment", DataType::Utf8, true),
+            Field::new(time_col, ts, true),
+        ],
+        "part" => vec![
+            Field::new("p_partkey", DataType::Int32, false),
+            Field::new("p_name", DataType::Utf8, false),
+            Field::new("p_mfgr", DataType::Utf8, false),
+            Field::new("p_brand", DataType::Utf8, false),
+            Field::new("p_type", DataType::Utf8, false),
+            Field::new("p_size", DataType::Int32, false),
+            Field::new("p_container", DataType::Utf8, false),
+            Field::new("p_retailprice", DataType::Decimal128(15, 2), false),
+            Field::new("p_comment", DataType::Utf8, true),
+            Field::new(time_col, ts, true),
+        ],
+        "partsupp" => vec![
+            Field::new("ps_partkey", DataType::Int32, false),
+            Field::new("ps_suppkey", DataType::Int32, false),
+            Field::new("ps_availqty", DataType::Int32, false),
+            Field::new("ps_supplycost", DataType::Decimal128(15, 2), false),
+            Field::new("ps_comment", DataType::Utf8, true),
+            Field::new(time_col, ts, true),
+        ],
+        "orders" => vec![
+            Field::new("o_orderkey", DataType::Int32, false),
+            Field::new("o_custkey", DataType::Int32, false),
+            Field::new("o_orderstatus", DataType::Utf8, false),
+            Field::new("o_totalprice", DataType::Decimal128(15, 2), false),
+            Field::new("o_orderdate", DataType::Date32, false),
+            Field::new("o_orderpriority", DataType::Utf8, false),
+            Field::new("o_clerk", DataType::Utf8, false),
+            Field::new("o_shippriority", DataType::Int32, false),
+            Field::new("o_comment", DataType::Utf8, true),
+            Field::new(time_col, ts, true),
+        ],
+        "lineitem" => vec![
+            Field::new("l_orderkey", DataType::Int32, false),
+            Field::new("l_partkey", DataType::Int32, false),
+            Field::new("l_suppkey", DataType::Int32, false),
+            Field::new("l_linenumber", DataType::Int32, false),
+            Field::new("l_quantity", DataType::Decimal128(15, 2), false),
+            Field::new("l_extendedprice", DataType::Decimal128(15, 2), false),
+            Field::new("l_discount", DataType::Decimal128(15, 2), false),
+            Field::new("l_tax", DataType::Decimal128(15, 2), false),
+            Field::new("l_returnflag", DataType::Utf8, false),
+            Field::new("l_linestatus", DataType::Utf8, false),
+            Field::new("l_shipdate", DataType::Date32, false),
+            Field::new("l_commitdate", DataType::Date32, false),
+            Field::new("l_receiptdate", DataType::Date32, false),
+            Field::new("l_shipinstruct", DataType::Utf8, false),
+            Field::new("l_shipmode", DataType::Utf8, false),
+            Field::new("l_comment", DataType::Utf8, true),
+            Field::new(time_col, ts, true),
+        ],
+        _ => unreachable!("unknown TPC-H table: {table}"),
+    };
+    Arc::new(Schema::new(fields))
+}
 
 /// Generates TPC-H data using DuckDB's built-in `dbgen` and yields Arrow `RecordBatch`es.
 ///
@@ -46,8 +143,8 @@ pub struct TpchDataset {
     conn: Connection,
     scale_factor: f64,
 
-    /// Index into `TPCH_TABLE_TIME_COLUMNS` for the current table being read.
-    table_index: usize,
+    /// Tables that have already been consumed in the current step.
+    consumed_tables: HashSet<String>,
 
     /// Step-based generation for continuous appends.
     /// Step 0 is the initial `dbgen` call; steps 1+ generate new non-overlapping data.
@@ -85,7 +182,7 @@ impl TpchDataset {
         Ok(Self {
             conn,
             scale_factor: config.scale_factor,
-            table_index: 0,
+            consumed_tables: HashSet::new(),
             current_step: 0,
             num_steps: config.num_steps,
         })
@@ -118,8 +215,6 @@ impl TpchDataset {
 
         info!(step = self.current_step, "Generated new TPC-H data step");
 
-        self.table_index = 0;
-
         Ok(true)
     }
 
@@ -135,54 +230,61 @@ impl TpchDataset {
 }
 
 impl Dataset for TpchDataset {
-    fn next_batch(&mut self) -> anyhow::Result<Option<DatasetBatch>> {
-        loop {
-            if self.table_index >= TPCH_TABLE_TIME_COLUMNS.len() {
-                // All tables exhausted for current step — drop _new tables and advance
-                if self.current_step > 0 {
-                    self.drop_step_tables()?;
-                }
-                if !self.advance_step()? {
-                    return Ok(None); // all steps exhausted
-                }
-                continue;
+    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+        // If all tables consumed for current step, advance to next step
+        if self.consumed_tables.len() >= TPCH_TABLE_TIME_COLUMNS.len() {
+            if self.current_step > 0 {
+                self.drop_step_tables()?;
             }
-
-            let (table, _) = TPCH_TABLE_TIME_COLUMNS[self.table_index];
-            let source_table = if self.current_step == 0 {
-                table.to_string()
-            } else {
-                format!("{table}_new")
-            };
-
-            let sql = format!("SELECT * FROM {source_table}");
-            let mut stmt = self.conn.prepare(&sql)?;
-            let batches: Vec<RecordBatch> = stmt.query_arrow([])?.collect();
-
-            self.table_index += 1;
-
-            if batches.is_empty() || batches[0].num_rows() == 0 {
-                continue;
+            if !self.advance_step()? {
+                return Ok(None); // all steps exhausted
             }
-
-            return Ok(Some(DatasetBatch {
-                table_name: table.to_string(),
-                batch: batches.into_iter().next().expect("checked non-empty"),
-            }));
+            self.consumed_tables.clear();
         }
+
+        // If this table was already consumed in the current step
+        if self.consumed_tables.contains(table) {
+            return Ok(None);
+        }
+
+        // Validate the table name
+        if !TPCH_TABLE_TIME_COLUMNS
+            .iter()
+            .any(|(name, _)| *name == table)
+        {
+            anyhow::bail!("Unknown TPC-H table: {table}");
+        }
+
+        let source_table = if self.current_step == 0 {
+            table.to_string()
+        } else {
+            format!("{table}_new")
+        };
+
+        let sql = format!("SELECT * FROM {source_table}");
+        let mut stmt = self.conn.prepare(&sql)?;
+        let batches: Vec<RecordBatch> = stmt.query_arrow([])?.collect();
+
+        self.consumed_tables.insert(table.to_string());
+
+        if batches.is_empty() || batches[0].num_rows() == 0 {
+            return Ok(None);
+        }
+
+        Ok(Some(DatasetBatch {
+            table_name: table.to_string(),
+            batch: batches.into_iter().next().expect("checked non-empty"),
+        }))
     }
 
-    fn tables(&self) -> Vec<String> {
+    fn tables(&self) -> Vec<DatasetTable> {
         TPCH_TABLE_TIME_COLUMNS
             .iter()
-            .map(|(name, _)| (*name).to_string())
+            .map(|(name, time_col)| DatasetTable {
+                name: (*name).to_string(),
+                schema: tpch_schema(name, time_col),
+                time_column: Some((*time_col).to_string()),
+            })
             .collect()
-    }
-
-    fn time_column(&self, table: &str) -> Option<String> {
-        TPCH_TABLE_TIME_COLUMNS
-            .iter()
-            .find(|(name, _)| *name == table)
-            .map(|(_, col)| (*col).to_string())
     }
 }

--- a/crates/data-generation/src/ingestor.rs
+++ b/crates/data-generation/src/ingestor.rs
@@ -25,8 +25,6 @@ use crate::dataset::Dataset;
 use crate::metrics::{IngestResult, Metrics};
 use crate::target::Target;
 
-use std::collections::HashSet;
-
 pub struct Ingestor<S: Dataset, T: Target> {
     dataset: S,
     target: T,
@@ -48,9 +46,8 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
 
     /// Seed the target with initial data — writes at least one batch per table.
     ///
-    /// Pulls batches from the dataset until every table has been written at least once,
-    /// then returns. Writes are performed sequentially (no concurrency) so the data is
-    /// guaranteed to be present when this returns.
+    /// Pulls one batch per table from the dataset using `next_batches()`, then writes
+    /// them sequentially so the data is guaranteed to be present when this returns.
     ///
     /// If `table_location_fn` is provided, prints a JSON object mapping each table to
     /// its connector and location, e.g.:
@@ -70,55 +67,50 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
                 );
                 entry.insert(
                     "location".to_string(),
-                    serde_json::Value::String(loc_fn(&table)),
+                    serde_json::Value::String(loc_fn(&table.name)),
                 );
-                if let Some(time_col) = self.dataset.time_column(&table) {
+                if let Some(ref time_col) = table.time_column {
                     entry.insert(
                         "time_column".to_string(),
-                        serde_json::Value::String(time_col),
+                        serde_json::Value::String(time_col.clone()),
                     );
                 }
-                map.insert(table, serde_json::Value::Object(entry));
+                map.insert(table.name, serde_json::Value::Object(entry));
             }
             println!("{}", serde_json::Value::Object(map));
         }
 
-        let all_tables: HashSet<String> = self.dataset.tables().into_iter().collect();
-        let mut tables_written: HashSet<String> = HashSet::new();
+        let table_count = self.dataset.tables().len();
 
         tracing::info!(
-            table_count = all_tables.len(),
+            table_count,
             "Initializing target with seed data for all tables"
         );
 
-        while tables_written.len() < all_tables.len() {
-            let source_batch = match self.dataset.next_batch() {
-                Ok(Some(batch)) => batch,
-                Ok(None) => {
-                    let missing: Vec<_> = all_tables.difference(&tables_written).collect();
-                    tracing::warn!(?missing, "Dataset exhausted before all tables were written");
-                    break;
+        match self.dataset.next_batches() {
+            Ok(Some(batches)) => {
+                for source_batch in batches {
+                    self.metrics.record_generation();
+
+                    let start = Instant::now();
+                    let result = self
+                        .target
+                        .write(&source_batch.table_name, self.batch_id, source_batch.batch)
+                        .await?;
+                    self.metrics.record_write(&result, start.elapsed());
+                    self.batch_id += 1;
                 }
-                Err(e) => return Err(e),
-            };
-            self.metrics.record_generation();
-
-            tables_written.insert(source_batch.table_name.clone());
-
-            let start = Instant::now();
-            let result = self
-                .target
-                .write(&source_batch.table_name, self.batch_id, source_batch.batch)
-                .await?;
-            self.metrics.record_write(&result, start.elapsed());
-            self.batch_id += 1;
+            }
+            Ok(None) => {
+                tracing::warn!("Dataset exhausted during initialization");
+            }
+            Err(e) => return Err(e),
         }
 
         let summary = self.metrics.summary();
         tracing::info!(
             rows = summary.rows_written,
             batches = summary.batches_written,
-            tables = tables_written.len(),
             "Initialization complete"
         );
 
@@ -127,31 +119,25 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
 
     /// Skip the initial batches that `initialize()` would have written.
     ///
-    /// Consumes batches from the dataset until every table has been seen at least once,
-    /// without writing them to the target. This advances the dataset past the
-    /// initialization records so that `run()` only processes new data.
+    /// Consumes one round of batches (one per table) from the dataset without writing
+    /// them to the target. This advances the dataset past the initialization records
+    /// so that `run()` only processes new data.
     pub fn skip_initial_batches(&mut self) -> anyhow::Result<()> {
-        let all_tables: HashSet<String> = self.dataset.tables().into_iter().collect();
-        let mut tables_seen: HashSet<String> = HashSet::new();
+        let table_count = self.dataset.tables().len();
 
         tracing::info!(
-            table_count = all_tables.len(),
+            table_count,
             "Skipping initial batches for all tables"
         );
 
-        while tables_seen.len() < all_tables.len() {
-            match self.dataset.next_batch() {
-                Ok(Some(batch)) => {
-                    tables_seen.insert(batch.table_name);
-                    self.batch_id += 1;
-                }
-                Ok(None) => {
-                    let missing: Vec<_> = all_tables.difference(&tables_seen).collect();
-                    tracing::warn!(?missing, "Dataset exhausted before all tables were skipped");
-                    break;
-                }
-                Err(e) => return Err(e),
+        match self.dataset.next_batches() {
+            Ok(Some(batches)) => {
+                self.batch_id += batches.len() as u64;
             }
+            Ok(None) => {
+                tracing::warn!("Dataset exhausted before all tables were skipped");
+            }
+            Err(e) => return Err(e),
         }
 
         tracing::info!(batches_skipped = self.batch_id, "Initial batches skipped");
@@ -178,39 +164,42 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
         });
 
         loop {
-            let source_batch = match self.dataset.next_batch() {
-                Ok(Some(batch)) => batch,
+            let source_batches = match self.dataset.next_batches() {
+                Ok(Some(batches)) => batches,
                 Ok(None) => break,
                 Err(e) => {
                     tracing::error!("Dataset error: {e}");
                     break;
                 }
             };
-            self.metrics.record_generation();
 
-            // Acquire semaphore permit — creates backpressure if all write slots are busy
-            let permit = Arc::clone(&self.semaphore).acquire_owned().await?;
+            for source_batch in source_batches {
+                self.metrics.record_generation();
 
-            let target = self.target.clone();
-            let metrics = self.metrics.clone();
-            let current_batch_id = self.batch_id;
-            let table_name = source_batch.table_name;
-            let batch = source_batch.batch;
-            self.batch_id += 1;
+                // Acquire semaphore permit — creates backpressure if all write slots are busy
+                let permit = Arc::clone(&self.semaphore).acquire_owned().await?;
 
-            join_set.spawn(async move {
-                let start = Instant::now();
-                match target.write(&table_name, current_batch_id, batch).await {
-                    Ok(result) => {
-                        metrics.record_write(&result, start.elapsed());
+                let target = self.target.clone();
+                let metrics = self.metrics.clone();
+                let current_batch_id = self.batch_id;
+                let table_name = source_batch.table_name;
+                let batch = source_batch.batch;
+                self.batch_id += 1;
+
+                join_set.spawn(async move {
+                    let start = Instant::now();
+                    match target.write(&table_name, current_batch_id, batch).await {
+                        Ok(result) => {
+                            metrics.record_write(&result, start.elapsed());
+                        }
+                        Err(e) => {
+                            metrics.record_error();
+                            tracing::error!(batch_id = current_batch_id, "Write failed: {e}");
+                        }
                     }
-                    Err(e) => {
-                        metrics.record_error();
-                        tracing::error!(batch_id = current_batch_id, "Write failed: {e}");
-                    }
-                }
-                drop(permit);
-            });
+                    drop(permit);
+                });
+            }
         }
 
         // Wait for all in-flight writes


### PR DESCRIPTION
This pull request significantly refactors the dataset abstraction in the data generation module, introducing richer table metadata, improving schema validation, and adding support for multi-table batch operations. It also implements a new simple sequence dataset and updates the TPCH dataset to use the new abstractions. The ingestor logic is simplified to take advantage of these changes.

**Dataset Abstraction and Schema Handling:**

- Introduced a new `DatasetTable` struct to encapsulate table metadata, including name, schema, and time column. The `Dataset` trait now returns a list of `DatasetTable` instead of just table names, and schema validation is performed when fetching batches. [[1]](diffhunk://#diff-d331f75f6543055bbc0bb233b92a8dd32e431dc3d94563497cca82534babfad9R18-R34) [[2]](diffhunk://#diff-d331f75f6543055bbc0bb233b92a8dd32e431dc3d94563497cca82534babfad9L28-R109)
- Added new methods to the `Dataset` trait: `raw_next_batch` for fetching data without validation, `next_batch` for validated single-table fetches, and `next_batches` to fetch a batch for every table in one call.

**New Dataset Implementation:**

- Added `simple_sequence.rs`, implementing `SimpleSequenceDataset`, a new dataset that generates a sequence of integers with an associated timestamp, using the new abstractions and schema validation.

**TPCH Dataset Refactor:**

- Refactored `TpchDataset` to use the new `DatasetTable` abstraction, including static schemas for each table and improved step-based data generation. Table consumption tracking is now per-table and per-step, and schema validation is enforced. [[1]](diffhunk://#diff-e6620ce163b2ae91169c987f7f2b33b39b057b533527550244f157fb4a241e65R17-R29) [[2]](diffhunk://#diff-e6620ce163b2ae91169c987f7f2b33b39b057b533527550244f157fb4a241e65R41-R134) [[3]](diffhunk://#diff-e6620ce163b2ae91169c987f7f2b33b39b057b533527550244f157fb4a241e65L49-R147) [[4]](diffhunk://#diff-e6620ce163b2ae91169c987f7f2b33b39b057b533527550244f157fb4a241e65L88-R185) [[5]](diffhunk://#diff-e6620ce163b2ae91169c987f7f2b33b39b057b533527550244f157fb4a241e65L121-L122) [[6]](diffhunk://#diff-e6620ce163b2ae91169c987f7f2b33b39b057b533527550244f157fb4a241e65L138-L151) [[7]](diffhunk://#diff-e6620ce163b2ae91169c987f7f2b33b39b057b533527550244f157fb4a241e65L162-L187)

**Ingestor Logic Simplification:**

- Updated the ingestor to use the new `next_batches` API, removing manual tracking of which tables have been written and simplifying the initialization logic. Table metadata is now used for reporting and mapping. [[1]](diffhunk://#diff-a58b33e50c1b77000accbefec60b4cfa42b00817445cf12a66ae173f8f71bebbL28-L29) [[2]](diffhunk://#diff-a58b33e50c1b77000accbefec60b4cfa42b00817445cf12a66ae173f8f71bebbL51-R50) [[3]](diffhunk://#diff-a58b33e50c1b77000accbefec60b4cfa42b00817445cf12a66ae173f8f71bebbL73-L107) [[4]](diffhunk://#diff-a58b33e50c1b77000accbefec60b4cfa42b00817445cf12a66ae173f8f71bebbR103-L121)

