### PR TITLE
refactor: Replace DatasetBatch with RecordBatch

### DIFF
--- a/crates/data-generation/src/dataset/mod.rs
+++ b/crates/data-generation/src/dataset/mod.rs
@@ -17,6 +17,7 @@ limitations under the License.
 pub mod tpch;
 pub mod simple_sequence;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
@@ -33,28 +34,21 @@ pub struct DatasetTable {
     pub time_column: Option<String>,
 }
 
-/// A batch of data from a dataset, tagged with its table name.
-pub struct DatasetBatch {
-    pub table_name: String,
-    pub batch: RecordBatch,
-}
-
 pub trait Dataset: Send {
     /// Returns the next raw batch of data for the given table, or `None` if exhausted.
     ///
     /// Most callers should use [`next_batch`]
     /// instead, which validates the table name and output schema.
-    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>>;
+    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<RecordBatch>>;
 
     /// Returns the next batch of data for the given table, or `None` if exhausted.
     ///
     /// Validates that `table` is a known table for this dataset, delegates to
     /// [`raw_next_batch`], and verifies the returned batch matches the expected schema.
-    fn next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+    fn next_batch(&mut self, table: &str) -> anyhow::Result<Option<RecordBatch>> {
         let tables = self.tables();
         let dataset_table = tables
-            .iter()
-            .find(|t| t.name == table)
+            .get(table)
             .ok_or_else(|| anyhow::anyhow!("Unknown table: {table}"))?;
         let expected_schema = Arc::clone(&dataset_table.schema);
 
@@ -62,10 +56,10 @@ pub trait Dataset: Send {
             return Ok(None);
         };
 
-        if batch.batch.schema() != expected_schema {
+        if batch.schema() != expected_schema {
             anyhow::bail!(
                 "Schema mismatch for table '{table}': expected {expected_schema}, got {}",
-                batch.batch.schema()
+                batch.schema()
             );
         }
 
@@ -73,12 +67,12 @@ pub trait Dataset: Send {
     }
 
     /// Returns a batch for every table. Returns `None` if all tables are exhausted.
-    fn next_batches(&mut self) -> anyhow::Result<Option<Vec<DatasetBatch>>> {
+    fn next_batches(&mut self) -> anyhow::Result<Option<HashMap<String, RecordBatch>>> {
         let tables = self.tables();
-        let mut batches = Vec::new();
-        for table in &tables {
-            if let Some(batch) = self.next_batch(&table.name)? {
-                batches.push(batch);
+        let mut batches = HashMap::new();
+        for (name, _) in &tables {
+            if let Some(batch) = self.next_batch(name)? {
+                batches.insert(name.clone(), batch);
             }
         }
         if batches.is_empty() {
@@ -88,24 +82,24 @@ pub trait Dataset: Send {
         }
     }
 
-    /// Returns the list of tables this dataset produces, including metadata.
-    fn tables(&self) -> Vec<DatasetTable>;
+    /// Returns the tables this dataset produces, including metadata, keyed by table name.
+    fn tables(&self) -> HashMap<String, DatasetTable>;
 }
 
 impl Dataset for Box<dyn Dataset> {
-    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<RecordBatch>> {
         (**self).raw_next_batch(table)
     }
 
-    fn next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+    fn next_batch(&mut self, table: &str) -> anyhow::Result<Option<RecordBatch>> {
         (**self).next_batch(table)
     }
 
-    fn next_batches(&mut self) -> anyhow::Result<Option<Vec<DatasetBatch>>> {
+    fn next_batches(&mut self) -> anyhow::Result<Option<HashMap<String, RecordBatch>>> {
         (**self).next_batches()
     }
 
-    fn tables(&self) -> Vec<DatasetTable> {
+    fn tables(&self) -> HashMap<String, DatasetTable> {
         (**self).tables()
     }
 }

--- a/crates/data-generation/src/dataset/simple_sequence.rs
+++ b/crates/data-generation/src/dataset/simple_sequence.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -22,7 +23,7 @@ use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 
 use crate::config::DatasetConfig;
 
-use super::{Dataset, DatasetBatch, DatasetTable};
+use super::{Dataset, DatasetTable};
 
 /// A simple dataset that generates a sequence of integers in a single table.
 ///
@@ -59,7 +60,7 @@ impl SimpleSequenceDataset {
 }
 
 impl Dataset for SimpleSequenceDataset {
-    fn raw_next_batch(&mut self, _table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+    fn raw_next_batch(&mut self, _table: &str) -> anyhow::Result<Option<RecordBatch>> {
         if self.remaining_steps == 0 {
             return Ok(None);
         }
@@ -85,17 +86,17 @@ impl Dataset for SimpleSequenceDataset {
             vec![Arc::new(ids), Arc::new(values), Arc::new(timestamps)],
         )?;
 
-        Ok(Some(DatasetBatch {
-            table_name: "integer_sequence".to_string(),
-            batch,
-        }))
+        Ok(Some(batch))
     }
 
-    fn tables(&self) -> Vec<DatasetTable> {
-        vec![DatasetTable {
-            name: "integer_sequence".to_string(),
-            schema: Self::schema(),
-            time_column: Some("inserted_at".to_string()),
-        }]
+    fn tables(&self) -> HashMap<String, DatasetTable> {
+        HashMap::from([(
+            "integer_sequence".to_string(),
+            DatasetTable {
+                name: "integer_sequence".to_string(),
+                schema: Self::schema(),
+                time_column: Some("inserted_at".to_string()),
+            },
+        )])
     }
 }

--- a/crates/data-generation/src/dataset/tpch.rs
+++ b/crates/data-generation/src/dataset/tpch.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
@@ -24,7 +24,7 @@ use tracing::info;
 
 use crate::config::DatasetConfig;
 
-use super::{Dataset, DatasetBatch, DatasetTable};
+use super::{Dataset, DatasetTable};
 
 /// TPC-H table definitions: (table_name, time_column, schema_fn).
 const TPCH_TABLE_TIME_COLUMNS: &[(&str, &str)] = &[
@@ -230,7 +230,7 @@ impl TpchDataset {
 }
 
 impl Dataset for TpchDataset {
-    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<DatasetBatch>> {
+    fn raw_next_batch(&mut self, table: &str) -> anyhow::Result<Option<RecordBatch>> {
         // If all tables consumed for current step, advance to next step
         if self.consumed_tables.len() >= TPCH_TABLE_TIME_COLUMNS.len() {
             if self.current_step > 0 {
@@ -271,19 +271,23 @@ impl Dataset for TpchDataset {
             return Ok(None);
         }
 
-        Ok(Some(DatasetBatch {
-            table_name: table.to_string(),
-            batch: batches.into_iter().next().expect("checked non-empty"),
-        }))
+        Ok(Some(
+            batches.into_iter().next().expect("checked non-empty"),
+        ))
     }
 
-    fn tables(&self) -> Vec<DatasetTable> {
+    fn tables(&self) -> HashMap<String, DatasetTable> {
         TPCH_TABLE_TIME_COLUMNS
             .iter()
-            .map(|(name, time_col)| DatasetTable {
-                name: (*name).to_string(),
-                schema: tpch_schema(name, time_col),
-                time_column: Some((*time_col).to_string()),
+            .map(|(name, time_col)| {
+                (
+                    (*name).to_string(),
+                    DatasetTable {
+                        name: (*name).to_string(),
+                        schema: tpch_schema(name, time_col),
+                        time_column: Some((*time_col).to_string()),
+                    },
+                )
             })
             .collect()
     }

--- a/crates/data-generation/src/ingestor.rs
+++ b/crates/data-generation/src/ingestor.rs
@@ -59,7 +59,7 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
         // Print table locations as JSON
         if let Some(loc_fn) = table_location_fn {
             let mut map = serde_json::Map::new();
-            for table in self.dataset.tables() {
+            for (name, table) in self.dataset.tables() {
                 let mut entry = serde_json::Map::new();
                 entry.insert(
                     "connector".to_string(),
@@ -67,7 +67,7 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
                 );
                 entry.insert(
                     "location".to_string(),
-                    serde_json::Value::String(loc_fn(&table.name)),
+                    serde_json::Value::String(loc_fn(&name)),
                 );
                 if let Some(ref time_col) = table.time_column {
                     entry.insert(
@@ -75,7 +75,7 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
                         serde_json::Value::String(time_col.clone()),
                     );
                 }
-                map.insert(table.name, serde_json::Value::Object(entry));
+                map.insert(name, serde_json::Value::Object(entry));
             }
             println!("{}", serde_json::Value::Object(map));
         }
@@ -89,13 +89,13 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
 
         match self.dataset.next_batches() {
             Ok(Some(batches)) => {
-                for source_batch in batches {
+                for (table_name, batch) in batches {
                     self.metrics.record_generation();
 
                     let start = Instant::now();
                     let result = self
                         .target
-                        .write(&source_batch.table_name, self.batch_id, source_batch.batch)
+                        .write(&table_name, self.batch_id, batch)
                         .await?;
                     self.metrics.record_write(&result, start.elapsed());
                     self.batch_id += 1;
@@ -173,7 +173,7 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
                 }
             };
 
-            for source_batch in source_batches {
+            for (table_name, batch) in source_batches {
                 self.metrics.record_generation();
 
                 // Acquire semaphore permit — creates backpressure if all write slots are busy
@@ -182,8 +182,6 @@ impl<S: Dataset, T: Target> Ingestor<S, T> {
                 let target = self.target.clone();
                 let metrics = self.metrics.clone();
                 let current_batch_id = self.batch_id;
-                let table_name = source_batch.table_name;
-                let batch = source_batch.batch;
                 self.batch_id += 1;
 
                 join_set.spawn(async move {


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Removes `DatasetBatch` as we know what table we're requesting
* Updates `tables()` to return a `HashMap<String, DatasetTable>` to make it easier to table existence checks