### PR TITLE
fix: Disable Rust toolchain cache

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.91
+          cache: false # Using GHA cache is slower than re-installing
 
       - name: cargo check
         run: cargo check --workspace
@@ -43,6 +44,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.91
+          cache: false # Using GHA cache is slower than re-installing
 
       - name: cargo clippy
         run: cargo clippy -p spicebench --all-targets -- -D warnings


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Toolchain uploads takes 20+ minutes