### PR TITLE
refactor: Move ingestor to new ETL crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,7 +1769,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -2775,6 +2774,19 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etl"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "data-generation",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "crates/adbc_client",
     "crates/app",
     "crates/data-generation",
-    "crates/duration-parse",
+    "crates/duration-parse", "crates/etl",
     "crates/flight_client",
     "crates/otel-arrow",
     "crates/spicepod",

--- a/crates/data-generation/Cargo.toml
+++ b/crates/data-generation/Cargo.toml
@@ -12,10 +12,6 @@ version.workspace = true
 name = "data_generation"
 path = "src/lib.rs"
 
-[[bin]]
-name = "data-generation"
-path = "src/main.rs"
-
 [dependencies]
 anyhow.workspace = true
 arrow = { workspace = true }
@@ -30,5 +26,4 @@ parquet.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "etl"
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lib]
+name = "etl"
+path = "src/lib.rs"
+
+[[bin]]
+name = "data-generation"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap = { workspace = true, features = ["derive"] }
+data-generation = { path = "../data-generation" }
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/etl/src/ingestor.rs
+++ b/crates/etl/src/ingestor.rs
@@ -20,10 +20,10 @@ use std::time::Instant;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
-use crate::config::IngestorConfig;
-use crate::dataset::Dataset;
-use crate::metrics::{IngestResult, Metrics};
-use crate::target::Target;
+use data_generation::config::IngestorConfig;
+use data_generation::dataset::Dataset;
+use data_generation::metrics::{IngestResult, Metrics};
+use data_generation::target::Target;
 
 pub struct Ingestor<S: Dataset, T: Target> {
     dataset: S,

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -14,7 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-pub mod config;
-pub mod dataset;
-pub mod metrics;
-pub mod target;
+pub mod ingestor;

--- a/crates/etl/src/main.rs
+++ b/crates/etl/src/main.rs
@@ -22,9 +22,9 @@ use std::sync::Arc;
 use data_generation::config::{Cli, Command, CommonArgs};
 use data_generation::dataset;
 use data_generation::dataset::tpch::TpchDataset;
-use data_generation::ingestor::Ingestor;
 use data_generation::metrics::{IngestResult, Metrics};
 use data_generation::target::s3::S3Target;
+use etl::ingestor::Ingestor;
 
 fn print_summary(result: &IngestResult) {
     println!("  Duration:          {:?}", result.elapsed);


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Creates a new `etl` crate where future ETL pipelining code will live
* Moves the `Ingestor` and data generation binary into the `etl` crate