### PR TITLE
feat: Add reproducible data downloads, data rehydration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,11 +1764,13 @@ dependencies = [
  "bytes",
  "clap",
  "duckdb",
+ "futures",
  "object_store",
  "parquet",
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/data-generation/Cargo.toml
+++ b/crates/data-generation/Cargo.toml
@@ -12,6 +12,10 @@ version.workspace = true
 name = "data_generation"
 path = "src/lib.rs"
 
+[[bin]]
+name = "data-generation"
+path = "src/main.rs"
+
 [dependencies]
 anyhow.workspace = true
 arrow = { workspace = true }
@@ -20,10 +24,12 @@ arrow-schema.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["derive"] }
+futures.workspace = true
 duckdb = { workspace = true, features = ["bundled", "vtab", "vtab-arrow"] }
 object_store = { workspace = true }
 parquet.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/data-generation/src/dataset/mod.rs
+++ b/crates/data-generation/src/dataset/mod.rs
@@ -19,9 +19,10 @@ pub mod simple_sequence;
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use arrow::array::RecordBatch;
-use arrow::datatypes::SchemaRef;
+use arrow::array::{RecordBatch, TimestampMicrosecondArray};
+use arrow::datatypes::{DataType, Field, SchemaRef, TimeUnit};
 use async_trait::async_trait;
 
 /// Metadata about a table in a dataset.
@@ -29,14 +30,81 @@ use async_trait::async_trait;
 pub struct DatasetTable {
     /// The name of the table.
     pub name: String,
-    /// The Arrow schema for the table.
+    /// The Arrow schema for the table (without the time column).
     pub schema: SchemaRef,
     /// The time column for the table, if any.
+    ///
+    /// When set, this column is *not* included in [`schema`] — it is appended
+    /// during rehydration via [`DatasetTable::rehydrate`].
     pub time_column: Option<String>,
+}
+
+impl DatasetTable {
+    /// Returns the full schema including the time column, if one is configured.
+    ///
+    /// If `time_column` is `None`, this returns the same schema as [`schema`].
+    pub fn rehydrated_schema(&self) -> SchemaRef {
+        let Some(ref time_col) = self.time_column else {
+            return Arc::clone(&self.schema);
+        };
+
+        let ts_type = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+        let mut fields: Vec<_> = self.schema.fields().iter().cloned().collect();
+        fields.push(Arc::new(Field::new(time_col, ts_type, true)));
+        Arc::new(arrow::datatypes::Schema::new(fields))
+    }
+
+    /// Rehydrate a batch by appending the time column with the current timestamp.
+    ///
+    /// If this table has no `time_column`, the batch is returned unchanged.
+    /// The batch schema must match [`schema`] (i.e. without the time column).
+    pub fn rehydrate(&self, batch: &RecordBatch) -> anyhow::Result<RecordBatch> {
+        if self.time_column.is_none() {
+            anyhow::bail!("Cannot rehydrate table '{}' without a time column", self.name);
+        }
+
+        if batch.schema() != self.schema {
+            anyhow::bail!(
+                "Schema mismatch for table '{}': expected {}, got {}",
+                self.name,
+                self.schema,
+                batch.schema()
+            );
+        }
+
+        let now_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time before UNIX epoch")
+            .as_micros() as i64;
+
+        let num_rows = batch.num_rows();
+        let timestamps = TimestampMicrosecondArray::from(vec![Some(now_us); num_rows])
+            .with_timezone("UTC");
+
+        let rehydrated_schema = self.rehydrated_schema();
+        let mut columns: Vec<_> = batch.columns().to_vec();
+        columns.push(Arc::new(timestamps));
+
+        Ok(RecordBatch::try_new(rehydrated_schema, columns)?)
+    }
 }
 
 #[async_trait]
 pub trait Dataset: Send + Sync {
+    /// Returns the batch IDs that would be produced for a given table after a
+    /// successful generation run.
+    ///
+    /// The default implementation returns `0..num_batches(table)`, but
+    /// implementations may override this to customise the ID scheme.
+    fn batch_ids(&self, table: &str) -> Vec<u64> {
+        (0..self.num_batches(table)).collect()
+    }
+
+    /// Returns the total number of batches this dataset will produce for the
+    /// given table. Implementations must provide this so that [`batch_ids`]
+    /// and downstream planning (e.g. `Target::expected_files`) can work.
+    fn num_batches(&self, table: &str) -> u64;
+
     /// Returns the next raw batch of data for the given table, or `None` if exhausted.
     ///
     /// Most callers should use [`next_batch`]
@@ -86,10 +154,31 @@ pub trait Dataset: Send + Sync {
 
     /// Returns the tables this dataset produces, including metadata, keyed by table name.
     fn tables(&self) -> HashMap<String, DatasetTable>;
+
+    /// Rehydrate a batch for the given table by appending the time column.
+    ///
+    /// Uses the table metadata from [`tables()`] to look up the time column name
+    /// and delegates to [`DatasetTable::rehydrate`]. If the table has no time column,
+    /// a rehydration error is returned.
+    fn rehydrate(&self, table: &str, batch: &RecordBatch) -> anyhow::Result<RecordBatch> {
+        let tables = self.tables();
+        let dataset_table = tables
+            .get(table)
+            .ok_or_else(|| anyhow::anyhow!("Unknown table: {table}"))?;
+        dataset_table.rehydrate(batch)
+    }
 }
 
 #[async_trait]
 impl Dataset for Arc<dyn Dataset> {
+    fn batch_ids(&self, table: &str) -> Vec<u64> {
+        (**self).batch_ids(table)
+    }
+
+    fn num_batches(&self, table: &str) -> u64 {
+        (**self).num_batches(table)
+    }
+
     async fn raw_next_batch(&self, table: &str) -> anyhow::Result<Option<RecordBatch>> {
         (**self).raw_next_batch(table).await
     }
@@ -104,5 +193,9 @@ impl Dataset for Arc<dyn Dataset> {
 
     fn tables(&self) -> HashMap<String, DatasetTable> {
         (**self).tables()
+    }
+
+    fn rehydrate(&self, table: &str, batch: &RecordBatch) -> anyhow::Result<RecordBatch> {
+        (**self).rehydrate(table, batch)
     }
 }

--- a/crates/data-generation/src/dataset/simple_sequence.rs
+++ b/crates/data-generation/src/dataset/simple_sequence.rs
@@ -17,10 +17,9 @@ limitations under the License.
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, AtomicU16, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
-use arrow::array::{Int64Array, RecordBatch, TimestampMicrosecondArray};
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use arrow::array::{Int64Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 
 use crate::config::DatasetConfig;
@@ -33,6 +32,7 @@ use super::{Dataset, DatasetTable};
 /// and `value = id * 10`. After `num_steps` batches the dataset is exhausted.
 pub struct SimpleSequenceDataset {
     batch_size: usize,
+    num_steps: u16,
     current_offset: AtomicI64,
     remaining_steps: AtomicU16,
 }
@@ -42,27 +42,31 @@ impl SimpleSequenceDataset {
         let batch_size = (config.scale_factor * 1000.0) as usize;
         Self {
             batch_size,
+            num_steps: config.num_steps,
             current_offset: AtomicI64::new(0),
             remaining_steps: AtomicU16::new(config.num_steps),
         }
     }
 
     /// Returns the static Arrow schema for the `integer_sequence` table.
+    ///
+    /// The time column (`inserted_at`) is not included; it will be added during
+    /// ETL rehydration.
     pub fn schema() -> SchemaRef {
         Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int64, false),
             Field::new("value", DataType::Int64, false),
-            Field::new(
-                "inserted_at",
-                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
-                true,
-            ),
         ]))
     }
 }
 
 #[async_trait]
 impl Dataset for SimpleSequenceDataset {
+    fn num_batches(&self, _table: &str) -> u64 {
+        // One batch per step for the single table.
+        u64::from(self.num_steps)
+    }
+
     async fn raw_next_batch(&self, _table: &str) -> anyhow::Result<Option<RecordBatch>> {
         let prev = self.remaining_steps.fetch_sub(1, Ordering::SeqCst);
         if prev == 0 {
@@ -71,11 +75,6 @@ impl Dataset for SimpleSequenceDataset {
             return Ok(None);
         }
 
-        let now_us = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time before UNIX epoch")
-            .as_micros() as i64;
-
         let offset = self.current_offset.fetch_add(self.batch_size as i64, Ordering::SeqCst);
 
         let ids: Int64Array = (offset..offset + self.batch_size as i64)
@@ -83,12 +82,10 @@ impl Dataset for SimpleSequenceDataset {
         let values: Int64Array = (offset..offset + self.batch_size as i64)
             .map(|id| id * 10)
             .collect();
-        let timestamps = TimestampMicrosecondArray::from(vec![Some(now_us); self.batch_size])
-            .with_timezone("UTC");
 
         let batch = RecordBatch::try_new(
             Self::schema(),
-            vec![Arc::new(ids), Arc::new(values), Arc::new(timestamps)],
+            vec![Arc::new(ids), Arc::new(values)],
         )?;
 
         Ok(Some(batch))

--- a/crates/data-generation/src/dataset/tpch.rs
+++ b/crates/data-generation/src/dataset/tpch.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 use arrow::array::RecordBatch;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
 use duckdb::Connection;
 use tracing::info;
@@ -40,22 +40,21 @@ const TPCH_TABLE_TIME_COLUMNS: &[(&str, &str)] = &[
     ("lineitem", "l_created_at"),
 ];
 
-/// Returns the static Arrow schema for a TPC-H table (including the appended time column).
-fn tpch_schema(table: &str, time_col: &str) -> SchemaRef {
-    let ts = DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()));
+/// Returns the static Arrow schema for a TPC-H table (without time column).
+///
+/// The time column is not included because it will be added during ETL rehydration.
+fn tpch_schema(table: &str) -> SchemaRef {
     let fields: Vec<Field> = match table {
         "region" => vec![
             Field::new("r_regionkey", DataType::Int32, false),
             Field::new("r_name", DataType::Utf8, false),
             Field::new("r_comment", DataType::Utf8, true),
-            Field::new(time_col, ts, true),
         ],
         "nation" => vec![
             Field::new("n_nationkey", DataType::Int32, false),
             Field::new("n_name", DataType::Utf8, false),
             Field::new("n_regionkey", DataType::Int32, false),
             Field::new("n_comment", DataType::Utf8, true),
-            Field::new(time_col, ts, true),
         ],
         "supplier" => vec![
             Field::new("s_suppkey", DataType::Int32, false),
@@ -65,7 +64,6 @@ fn tpch_schema(table: &str, time_col: &str) -> SchemaRef {
             Field::new("s_phone", DataType::Utf8, false),
             Field::new("s_acctbal", DataType::Decimal128(15, 2), false),
             Field::new("s_comment", DataType::Utf8, true),
-            Field::new(time_col, ts, true),
         ],
         "customer" => vec![
             Field::new("c_custkey", DataType::Int32, false),
@@ -76,7 +74,6 @@ fn tpch_schema(table: &str, time_col: &str) -> SchemaRef {
             Field::new("c_acctbal", DataType::Decimal128(15, 2), false),
             Field::new("c_mktsegment", DataType::Utf8, false),
             Field::new("c_comment", DataType::Utf8, true),
-            Field::new(time_col, ts, true),
         ],
         "part" => vec![
             Field::new("p_partkey", DataType::Int32, false),
@@ -88,7 +85,6 @@ fn tpch_schema(table: &str, time_col: &str) -> SchemaRef {
             Field::new("p_container", DataType::Utf8, false),
             Field::new("p_retailprice", DataType::Decimal128(15, 2), false),
             Field::new("p_comment", DataType::Utf8, true),
-            Field::new(time_col, ts, true),
         ],
         "partsupp" => vec![
             Field::new("ps_partkey", DataType::Int32, false),
@@ -96,7 +92,6 @@ fn tpch_schema(table: &str, time_col: &str) -> SchemaRef {
             Field::new("ps_availqty", DataType::Int32, false),
             Field::new("ps_supplycost", DataType::Decimal128(15, 2), false),
             Field::new("ps_comment", DataType::Utf8, true),
-            Field::new(time_col, ts, true),
         ],
         "orders" => vec![
             Field::new("o_orderkey", DataType::Int32, false),
@@ -108,7 +103,6 @@ fn tpch_schema(table: &str, time_col: &str) -> SchemaRef {
             Field::new("o_clerk", DataType::Utf8, false),
             Field::new("o_shippriority", DataType::Int32, false),
             Field::new("o_comment", DataType::Utf8, true),
-            Field::new(time_col, ts, true),
         ],
         "lineitem" => vec![
             Field::new("l_orderkey", DataType::Int32, false),
@@ -127,7 +121,6 @@ fn tpch_schema(table: &str, time_col: &str) -> SchemaRef {
             Field::new("l_shipinstruct", DataType::Utf8, false),
             Field::new("l_shipmode", DataType::Utf8, false),
             Field::new("l_comment", DataType::Utf8, true),
-            Field::new(time_col, ts, true),
         ],
         _ => unreachable!("unknown TPC-H table: {table}"),
     };
@@ -160,18 +153,11 @@ impl TpchDataset {
         let conn = Connection::open_in_memory()?;
 
         // Generate initial TPC-H data (step 0)
-        let mut sql = format!(
+        let sql = format!(
             "INSTALL tpch; LOAD tpch; CALL dbgen(sf={sf}, children={num_steps}, step=0);",
             sf = config.scale_factor,
             num_steps = config.num_steps,
         );
-
-        // Add time columns to each table
-        for (table, time_col) in TPCH_TABLE_TIME_COLUMNS {
-            sql.push_str(&format!(
-                "ALTER TABLE {table} ADD COLUMN {time_col} TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;"
-            ));
-        }
 
         conn.execute_batch(&sql)?;
 
@@ -199,19 +185,12 @@ impl TpchDataset {
             return Ok(false);
         }
 
-        let mut sql = format!(
+        let sql = format!(
             "CALL dbgen(sf={sf}, children={num_steps}, step={step}, suffix='_new');",
             sf = self.scale_factor,
             num_steps = self.num_steps,
             step = new_step,
         );
-
-        // Add time columns to _new tables
-        for (table, time_col) in TPCH_TABLE_TIME_COLUMNS {
-            sql.push_str(&format!(
-                "ALTER TABLE {table}_new ADD COLUMN {time_col} TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP;"
-            ));
-        }
 
         let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
         conn.execute_batch(&sql)?;
@@ -235,6 +214,17 @@ impl TpchDataset {
 
 #[async_trait]
 impl Dataset for TpchDataset {
+    fn num_batches(&self, table: &str) -> u64 {
+        if !TPCH_TABLE_TIME_COLUMNS
+            .iter()
+            .any(|(name, _)| *name == table)
+        {
+            return 0;
+        }
+        // TPC-H produces one batch per table per step.
+        u64::from(self.num_steps)
+    }
+
     async fn raw_next_batch(&self, table: &str) -> anyhow::Result<Option<RecordBatch>> {
         // If all tables consumed for current step, advance to next step
         {
@@ -305,7 +295,7 @@ impl Dataset for TpchDataset {
                     (*name).to_string(),
                     DatasetTable {
                         name: (*name).to_string(),
-                        schema: tpch_schema(name, time_col),
+                        schema: tpch_schema(name),
                         time_column: Some((*time_col).to_string()),
                     },
                 )

--- a/crates/data-generation/src/ingestor.rs
+++ b/crates/data-generation/src/ingestor.rs
@@ -20,21 +20,21 @@ use std::time::Instant;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 
-use data_generation::config::IngestorConfig;
-use data_generation::dataset::Dataset;
-use data_generation::metrics::{IngestResult, Metrics};
-use data_generation::target::Target;
+use super::config::IngestorConfig;
+use super::dataset::Dataset;
+use super::metrics::{IngestResult, Metrics};
+use super::target::Target;
 
-pub struct Ingestor<S: Dataset, T: Target> {
-    dataset: S,
-    target: T,
+pub struct Ingestor {
+    dataset: Arc<dyn Dataset>,
+    target: Arc<dyn Target>,
     metrics: Metrics,
     semaphore: Arc<Semaphore>,
     batch_id: u64,
 }
 
-impl<S: Dataset, T: Target> Ingestor<S, T> {
-    pub fn new(dataset: S, target: T, config: &IngestorConfig, metrics: Metrics) -> Self {
+impl Ingestor {
+    pub fn new(dataset: Arc<dyn Dataset>, target: Arc<dyn Target>, config: &IngestorConfig, metrics: Metrics) -> Self {
         Self {
             dataset,
             target,

--- a/crates/data-generation/src/lib.rs
+++ b/crates/data-generation/src/lib.rs
@@ -17,4 +17,6 @@ limitations under the License.
 pub mod config;
 pub mod dataset;
 pub mod metrics;
+pub mod source;
 pub mod target;
+pub mod ingestor;

--- a/crates/data-generation/src/main.rs
+++ b/crates/data-generation/src/main.rs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 use clap::Parser;
+use data_generation::target::Target;
 use tracing_subscriber::EnvFilter;
 
 use std::sync::Arc;
@@ -24,7 +25,7 @@ use data_generation::dataset;
 use data_generation::dataset::tpch::TpchDataset;
 use data_generation::metrics::{IngestResult, Metrics};
 use data_generation::target::s3::S3Target;
-use etl::ingestor::Ingestor;
+use data_generation::ingestor::Ingestor;
 
 fn print_summary(result: &IngestResult) {
     println!("  Duration:          {:?}", result.elapsed);
@@ -51,7 +52,7 @@ fn print_summary(result: &IngestResult) {
 
 fn build(
     args: &CommonArgs,
-) -> anyhow::Result<(Ingestor<Arc<dyn dataset::Dataset>, S3Target>, S3Target)> {
+) -> anyhow::Result<(Ingestor, Arc<S3Target>)> {
     let dataset_config = args.dataset_config();
     let target_config = args.target_config();
     let ingestor_config = args.ingestor_config();
@@ -70,10 +71,10 @@ fn build(
         other => anyhow::bail!("Unknown dataset type: {other}. Supported: tpch"),
     };
 
-    let target = S3Target::new(&target_config)?;
+    let target = Arc::new(S3Target::new(&target_config)?);
     let metrics = Metrics::new();
 
-    let ingestor = Ingestor::new(dataset, target.clone(), &ingestor_config, metrics);
+    let ingestor = Ingestor::new(dataset, Arc::clone(&target) as Arc<dyn Target>, &ingestor_config, metrics);
     Ok((ingestor, target))
 }
 

--- a/crates/data-generation/src/source/mod.rs
+++ b/crates/data-generation/src/source/mod.rs
@@ -19,24 +19,20 @@ pub mod s3;
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
 
-pub struct WriteResult {
-    pub rows_written: u64,
-    pub bytes_written: u64,
+pub struct ReadResult {
+    pub batches: Vec<RecordBatch>,
+    pub rows_read: u64,
+    pub bytes_read: u64,
 }
 
 #[async_trait]
-pub trait Target: Send + Sync + 'static {
-    async fn write(
-        &self,
-        table_name: &str,
-        batch_id: u64,
-        batch: RecordBatch,
-    ) -> anyhow::Result<WriteResult>;
+pub trait Source: Send + Sync + Clone + 'static {
+    /// List available batch object paths for a given table.
+    async fn list_batches(&self, table_name: &str) -> anyhow::Result<Vec<String>>;
 
-    /// Returns the list of file paths/URIs that would exist after a successful
-    /// generation for the given table and batch IDs.
+    /// Read a single batch from the source by its batch ID and table name.
     ///
-    /// This is a planning method — no I/O is performed. Each implementation
-    /// maps `(table_name, batch_id)` to its own path scheme (e.g. an S3 URI).
-    fn expected_files(&self, table_name: &str, batch_ids: &[u64]) -> Vec<String>;
+    /// The concrete implementation is responsible for mapping `(table_name,
+    /// batch_id)` to the underlying storage path.
+    async fn read_batch(&self, table_name: &str, batch_id: u64) -> anyhow::Result<ReadResult>;
 }

--- a/crates/data-generation/src/source/s3.rs
+++ b/crates/data-generation/src/source/s3.rs
@@ -1,0 +1,119 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::TryStreamExt;
+use object_store::aws::AmazonS3Builder;
+use object_store::path::Path as ObjectPath;
+use object_store::ObjectStore;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+use crate::config::TargetConfig;
+
+use super::{ReadResult, Source};
+
+/// Reads Parquet data from S3 (or S3-compatible storage).
+#[derive(Clone)]
+pub struct S3Source {
+    store: Arc<dyn ObjectStore>,
+    prefix: String,
+}
+
+impl S3Source {
+    /// Create a new [`S3Source`] from the same config used for [`S3Target`].
+    ///
+    /// The source and target typically share the same bucket/prefix, so they
+    /// reuse [`TargetConfig`] to avoid duplicating configuration structs.
+    pub fn new(config: &TargetConfig) -> anyhow::Result<Self> {
+        let mut builder = AmazonS3Builder::from_env().with_bucket_name(&config.bucket);
+
+        if let Some(region) = &config.region {
+            builder = builder.with_region(region);
+        }
+        if let Some(endpoint) = &config.endpoint
+            && !endpoint.is_empty()
+        {
+            builder = builder.with_endpoint(endpoint);
+            if endpoint.starts_with("http://") {
+                builder = builder.with_allow_http(true);
+            }
+        }
+
+        let store = Arc::new(builder.build()?);
+        Ok(Self {
+            store,
+            prefix: config.prefix.clone(),
+        })
+    }
+}
+
+#[async_trait]
+impl Source for S3Source {
+    async fn list_batches(&self, table_name: &str) -> anyhow::Result<Vec<String>> {
+        let prefix = if self.prefix.is_empty() {
+            ObjectPath::from(format!("{table_name}/"))
+        } else {
+            ObjectPath::from(format!("{}/{table_name}/", self.prefix))
+        };
+
+        let objects: Vec<_> = self
+            .store
+            .list(Some(&prefix))
+            .try_collect()
+            .await?;
+
+        let paths: Vec<String> = objects
+            .into_iter()
+            .filter(|meta| meta.location.as_ref().ends_with(".parquet"))
+            .map(|meta| meta.location.to_string())
+            .collect();
+
+        Ok(paths)
+    }
+
+    async fn read_batch(&self, table_name: &str, batch_id: u64) -> anyhow::Result<ReadResult> {
+        let location = if self.prefix.is_empty() {
+            ObjectPath::from(format!("{table_name}/batch-{batch_id:06}.parquet"))
+        } else {
+            ObjectPath::from(format!(
+                "{}/{table_name}/batch-{batch_id:06}.parquet",
+                self.prefix
+            ))
+        };
+
+        let get_result = self.store.get(&location).await?;
+        let bytes = get_result.bytes().await?;
+        let bytes_read = bytes.len() as u64;
+
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes)?.build()?;
+
+        let mut batches = Vec::new();
+        let mut rows_read = 0u64;
+        for batch in reader {
+            let batch = batch?;
+            rows_read += batch.num_rows() as u64;
+            batches.push(batch);
+        }
+
+        Ok(ReadResult {
+            batches,
+            rows_read,
+            bytes_read,
+        })
+    }
+}

--- a/crates/data-generation/src/target/s3.rs
+++ b/crates/data-generation/src/target/s3.rs
@@ -24,7 +24,6 @@ use object_store::{ObjectStore, PutPayload};
 use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
-use uuid::Uuid;
 
 use crate::config::TargetConfig;
 
@@ -73,6 +72,25 @@ impl S3Target {
 
 #[async_trait]
 impl Target for S3Target {
+    fn expected_files(&self, table_name: &str, batch_ids: &[u64]) -> Vec<String> {
+        batch_ids
+            .iter()
+            .map(|id| {
+                if self.prefix.is_empty() {
+                    format!(
+                        "s3://{}/{table_name}/batch-{id:06}.parquet",
+                        self.bucket
+                    )
+                } else {
+                    format!(
+                        "s3://{}/{}/{table_name}/batch-{id:06}.parquet",
+                        self.bucket, self.prefix
+                    )
+                }
+            })
+            .collect()
+    }
+
     async fn write(
         &self,
         table_name: &str,
@@ -95,12 +113,11 @@ impl Target for S3Target {
         let bytes_written = buf.len() as u64;
 
         // Upload to S3 with per-table directory structure
-        let uuid = Uuid::new_v4();
         let path = if self.prefix.is_empty() {
-            ObjectPath::from(format!("{table_name}/batch-{batch_id:06}-{uuid}.parquet"))
+            ObjectPath::from(format!("{table_name}/batch-{batch_id:06}.parquet"))
         } else {
             ObjectPath::from(format!(
-                "{}/{table_name}/batch-{batch_id:06}-{uuid}.parquet",
+                "{}/{table_name}/batch-{batch_id:06}.parquet",
                 self.prefix
             ))
         };

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -12,10 +12,6 @@ version.workspace = true
 name = "etl"
 path = "src/lib.rs"
 
-[[bin]]
-name = "data-generation"
-path = "src/main.rs"
-
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -14,4 +14,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-pub mod ingestor;


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Removes the timestamp column from the pre-generated `Dataset` data to allow the ETL pipeline to rehydrate it from a pre-generated set
* Add trait methods on `Dataset` to rehydrate batches with timestamp data
* Adds a `Source` which downloads a pre-existing batch based on a table name and batch ID
* Moves the `Ingestor` back to `data-generation` as we actually want that there for generating the pre-existing datasets