### PR TITLE
feat: Implement basic ETL pipeline for creates with rehydrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,7 +2786,9 @@ dependencies = [
  "clap",
  "data-generation",
  "serde_json",
+ "system-adapter-protocol",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/data-generation/README.md
+++ b/crates/data-generation/README.md
@@ -1,0 +1,5 @@
+# Data Generator
+
+```bash
+cargo run -p data-generation -- run --scale-factor 1 --bucket peasee-indexes --region us-west-2 --prefix raw --num-steps 10
+```

--- a/crates/data-generation/src/config.rs
+++ b/crates/data-generation/src/config.rs
@@ -52,7 +52,7 @@ pub struct CommonArgs {
     pub scale_factor: f64,
 
     /// Number of data generation steps (partitions for TPC-H dbgen)
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 25)]
     pub num_steps: u16,
 
     /// S3 bucket name
@@ -72,7 +72,7 @@ pub struct CommonArgs {
     pub endpoint: Option<String>,
 
     /// Maximum number of concurrent S3 writes
-    #[arg(long, default_value_t = 8)]
+    #[arg(long, default_value_t = 16)]
     pub max_concurrency: usize,
 }
 

--- a/crates/data-generation/src/dataset/mod.rs
+++ b/crates/data-generation/src/dataset/mod.rs
@@ -25,6 +25,8 @@ use arrow::array::{RecordBatch, TimestampMicrosecondArray};
 use arrow::datatypes::{DataType, Field, SchemaRef, TimeUnit};
 use async_trait::async_trait;
 
+use crate::config::DatasetConfig;
+
 /// Metadata about a table in a dataset.
 #[derive(Debug, Clone)]
 pub struct DatasetTable {
@@ -91,6 +93,21 @@ impl DatasetTable {
 
 #[async_trait]
 pub trait Dataset: Send + Sync {
+    /// Creates a new instance of this dataset from the given configuration.
+    ///
+    /// This is a factory method that returns an `Arc<dyn Dataset>` without any
+    /// external side-effects beyond initialising in-memory state.
+    ///
+    /// The default implementation returns an error; concrete dataset types
+    /// should override this.
+    fn create(config: &DatasetConfig) -> anyhow::Result<Arc<dyn Dataset>>
+    where
+        Self: Sized + 'static,
+    {
+        let _ = config;
+        anyhow::bail!("create() is not implemented for this dataset type")
+    }
+
     /// Returns the batch IDs that would be produced for a given table after a
     /// successful generation run.
     ///

--- a/crates/data-generation/src/dataset/mod.rs
+++ b/crates/data-generation/src/dataset/mod.rs
@@ -17,7 +17,7 @@ limitations under the License.
 pub mod tpch;
 pub mod simple_sequence;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -66,11 +66,41 @@ impl DatasetTable {
         }
 
         if batch.schema() != self.schema {
+            let mut diffs = Vec::new();
+            let expected_fields = self.schema.fields();
+            let actual_schema = batch.schema();
+            let actual_fields = actual_schema.fields();
+
+            for (i, expected) in expected_fields.iter().enumerate() {
+                match actual_fields.get(i) {
+                    Some(actual) if actual != expected => {
+                        if actual.name() != expected.name() {
+                            diffs.push(format!("  column {i}: expected name '{}', got '{}'", expected.name(), actual.name()));
+                        }
+                        if actual.data_type() != expected.data_type() {
+                            diffs.push(format!("  column '{}' (index {i}): expected type {:?}, got {:?}", expected.name(), expected.data_type(), actual.data_type()));
+                        }
+                        if actual.is_nullable() != expected.is_nullable() {
+                            diffs.push(format!("  column '{}' (index {i}): expected nullable={}, got nullable={}", expected.name(), expected.is_nullable(), actual.is_nullable()));
+                        }
+                    }
+                    None => {
+                        diffs.push(format!("  column '{}' (index {i}): missing from batch", expected.name()));
+                    }
+                    _ => {}
+                }
+            }
+            for i in expected_fields.len()..actual_fields.len() {
+                diffs.push(format!("  column '{}' (index {i}): unexpected extra column in batch", actual_fields[i].name()));
+            }
+            if expected_fields.len() != actual_fields.len() {
+                diffs.push(format!("  expected {} columns, got {}", expected_fields.len(), actual_fields.len()));
+            }
+
             anyhow::bail!(
-                "Schema mismatch for table '{}': expected {}, got {}",
+                "Schema mismatch for table '{}':\n{}",
                 self.name,
-                self.schema,
-                batch.schema()
+                diffs.join("\n")
             );
         }
 
@@ -113,7 +143,7 @@ pub trait Dataset: Send + Sync {
     ///
     /// The default implementation returns `0..num_batches(table)`, but
     /// implementations may override this to customise the ID scheme.
-    fn batch_ids(&self, table: &str) -> Vec<u64> {
+    fn batch_ids(&self, table: &str) -> VecDeque<u64> {
         (0..self.num_batches(table)).collect()
     }
 
@@ -144,9 +174,40 @@ pub trait Dataset: Send + Sync {
         };
 
         if batch.schema() != expected_schema {
+            let mut diffs = Vec::new();
+            let expected_fields = expected_schema.fields();
+            let actual_schema = batch.schema();
+            let actual_fields = actual_schema.fields();
+
+            for (i, expected) in expected_fields.iter().enumerate() {
+                match actual_fields.get(i) {
+                    Some(actual) if actual != expected => {
+                        if actual.name() != expected.name() {
+                            diffs.push(format!("  column {i}: expected name '{}', got '{}'", expected.name(), actual.name()));
+                        }
+                        if actual.data_type() != expected.data_type() {
+                            diffs.push(format!("  column '{}' (index {i}): expected type {:?}, got {:?}", expected.name(), expected.data_type(), actual.data_type()));
+                        }
+                        if actual.is_nullable() != expected.is_nullable() {
+                            diffs.push(format!("  column '{}' (index {i}): expected nullable={}, got nullable={}", expected.name(), expected.is_nullable(), actual.is_nullable()));
+                        }
+                    }
+                    None => {
+                        diffs.push(format!("  column '{}' (index {i}): missing from batch", expected.name()));
+                    }
+                    _ => {}
+                }
+            }
+            for i in expected_fields.len()..actual_fields.len() {
+                diffs.push(format!("  column '{}' (index {i}): unexpected extra column in batch", actual_fields[i].name()));
+            }
+            if expected_fields.len() != actual_fields.len() {
+                diffs.push(format!("  expected {} columns, got {}", expected_fields.len(), actual_fields.len()));
+            }
+
             anyhow::bail!(
-                "Schema mismatch for table '{table}': expected {expected_schema}, got {}",
-                batch.schema()
+                "Schema mismatch for table '{table}':\n{}",
+                diffs.join("\n")
             );
         }
 
@@ -188,7 +249,7 @@ pub trait Dataset: Send + Sync {
 
 #[async_trait]
 impl Dataset for Arc<dyn Dataset> {
-    fn batch_ids(&self, table: &str) -> Vec<u64> {
+    fn batch_ids(&self, table: &str) -> VecDeque<u64> {
         (**self).batch_ids(table)
     }
 

--- a/crates/data-generation/src/dataset/simple_sequence.rs
+++ b/crates/data-generation/src/dataset/simple_sequence.rs
@@ -62,6 +62,13 @@ impl SimpleSequenceDataset {
 
 #[async_trait]
 impl Dataset for SimpleSequenceDataset {
+    fn create(config: &DatasetConfig) -> anyhow::Result<Arc<dyn Dataset>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Arc::new(Self::new(config)))
+    }
+
     fn num_batches(&self, _table: &str) -> u64 {
         // One batch per step for the single table.
         u64::from(self.num_steps)

--- a/crates/data-generation/src/dataset/tpch.rs
+++ b/crates/data-generation/src/dataset/tpch.rs
@@ -46,80 +46,80 @@ const TPCH_TABLE_TIME_COLUMNS: &[(&str, &str)] = &[
 fn tpch_schema(table: &str) -> SchemaRef {
     let fields: Vec<Field> = match table {
         "region" => vec![
-            Field::new("r_regionkey", DataType::Int32, false),
-            Field::new("r_name", DataType::Utf8, false),
+            Field::new("r_regionkey", DataType::Int32, true),
+            Field::new("r_name", DataType::Utf8, true),
             Field::new("r_comment", DataType::Utf8, true),
         ],
         "nation" => vec![
-            Field::new("n_nationkey", DataType::Int32, false),
-            Field::new("n_name", DataType::Utf8, false),
-            Field::new("n_regionkey", DataType::Int32, false),
+            Field::new("n_nationkey", DataType::Int32, true),
+            Field::new("n_name", DataType::Utf8, true),
+            Field::new("n_regionkey", DataType::Int32, true),
             Field::new("n_comment", DataType::Utf8, true),
         ],
         "supplier" => vec![
-            Field::new("s_suppkey", DataType::Int32, false),
-            Field::new("s_name", DataType::Utf8, false),
-            Field::new("s_address", DataType::Utf8, false),
-            Field::new("s_nationkey", DataType::Int32, false),
-            Field::new("s_phone", DataType::Utf8, false),
-            Field::new("s_acctbal", DataType::Decimal128(15, 2), false),
+            Field::new("s_suppkey", DataType::Int64, true),
+            Field::new("s_name", DataType::Utf8, true),
+            Field::new("s_address", DataType::Utf8, true),
+            Field::new("s_nationkey", DataType::Int32, true),
+            Field::new("s_phone", DataType::Utf8, true),
+            Field::new("s_acctbal", DataType::Decimal128(15, 2), true),
             Field::new("s_comment", DataType::Utf8, true),
         ],
         "customer" => vec![
-            Field::new("c_custkey", DataType::Int32, false),
-            Field::new("c_name", DataType::Utf8, false),
-            Field::new("c_address", DataType::Utf8, false),
-            Field::new("c_nationkey", DataType::Int32, false),
-            Field::new("c_phone", DataType::Utf8, false),
-            Field::new("c_acctbal", DataType::Decimal128(15, 2), false),
-            Field::new("c_mktsegment", DataType::Utf8, false),
+            Field::new("c_custkey", DataType::Int64, true),
+            Field::new("c_name", DataType::Utf8, true),
+            Field::new("c_address", DataType::Utf8, true),
+            Field::new("c_nationkey", DataType::Int32, true),
+            Field::new("c_phone", DataType::Utf8, true),
+            Field::new("c_acctbal", DataType::Decimal128(15, 2), true),
+            Field::new("c_mktsegment", DataType::Utf8, true),
             Field::new("c_comment", DataType::Utf8, true),
         ],
         "part" => vec![
-            Field::new("p_partkey", DataType::Int32, false),
-            Field::new("p_name", DataType::Utf8, false),
-            Field::new("p_mfgr", DataType::Utf8, false),
-            Field::new("p_brand", DataType::Utf8, false),
-            Field::new("p_type", DataType::Utf8, false),
-            Field::new("p_size", DataType::Int32, false),
-            Field::new("p_container", DataType::Utf8, false),
-            Field::new("p_retailprice", DataType::Decimal128(15, 2), false),
+            Field::new("p_partkey", DataType::Int64, true),
+            Field::new("p_name", DataType::Utf8, true),
+            Field::new("p_mfgr", DataType::Utf8, true),
+            Field::new("p_brand", DataType::Utf8, true),
+            Field::new("p_type", DataType::Utf8, true),
+            Field::new("p_size", DataType::Int32, true),
+            Field::new("p_container", DataType::Utf8, true),
+            Field::new("p_retailprice", DataType::Decimal128(15, 2), true),
             Field::new("p_comment", DataType::Utf8, true),
         ],
         "partsupp" => vec![
-            Field::new("ps_partkey", DataType::Int32, false),
-            Field::new("ps_suppkey", DataType::Int32, false),
-            Field::new("ps_availqty", DataType::Int32, false),
-            Field::new("ps_supplycost", DataType::Decimal128(15, 2), false),
+            Field::new("ps_partkey", DataType::Int64, true),
+            Field::new("ps_suppkey", DataType::Int64, true),
+            Field::new("ps_availqty", DataType::Int64, true),
+            Field::new("ps_supplycost", DataType::Decimal128(15, 2), true),
             Field::new("ps_comment", DataType::Utf8, true),
         ],
         "orders" => vec![
-            Field::new("o_orderkey", DataType::Int32, false),
-            Field::new("o_custkey", DataType::Int32, false),
-            Field::new("o_orderstatus", DataType::Utf8, false),
-            Field::new("o_totalprice", DataType::Decimal128(15, 2), false),
-            Field::new("o_orderdate", DataType::Date32, false),
-            Field::new("o_orderpriority", DataType::Utf8, false),
-            Field::new("o_clerk", DataType::Utf8, false),
-            Field::new("o_shippriority", DataType::Int32, false),
+            Field::new("o_orderkey", DataType::Int64, true),
+            Field::new("o_custkey", DataType::Int64, true),
+            Field::new("o_orderstatus", DataType::Utf8, true),
+            Field::new("o_totalprice", DataType::Decimal128(15, 2), true),
+            Field::new("o_orderdate", DataType::Date32, true),
+            Field::new("o_orderpriority", DataType::Utf8, true),
+            Field::new("o_clerk", DataType::Utf8, true),
+            Field::new("o_shippriority", DataType::Int32, true),
             Field::new("o_comment", DataType::Utf8, true),
         ],
         "lineitem" => vec![
-            Field::new("l_orderkey", DataType::Int32, false),
-            Field::new("l_partkey", DataType::Int32, false),
-            Field::new("l_suppkey", DataType::Int32, false),
-            Field::new("l_linenumber", DataType::Int32, false),
-            Field::new("l_quantity", DataType::Decimal128(15, 2), false),
-            Field::new("l_extendedprice", DataType::Decimal128(15, 2), false),
-            Field::new("l_discount", DataType::Decimal128(15, 2), false),
-            Field::new("l_tax", DataType::Decimal128(15, 2), false),
-            Field::new("l_returnflag", DataType::Utf8, false),
-            Field::new("l_linestatus", DataType::Utf8, false),
-            Field::new("l_shipdate", DataType::Date32, false),
-            Field::new("l_commitdate", DataType::Date32, false),
-            Field::new("l_receiptdate", DataType::Date32, false),
-            Field::new("l_shipinstruct", DataType::Utf8, false),
-            Field::new("l_shipmode", DataType::Utf8, false),
+            Field::new("l_orderkey", DataType::Int64, true),
+            Field::new("l_partkey", DataType::Int64, true),
+            Field::new("l_suppkey", DataType::Int64, true),
+            Field::new("l_linenumber", DataType::Int64, true),
+            Field::new("l_quantity", DataType::Decimal128(15, 2), true),
+            Field::new("l_extendedprice", DataType::Decimal128(15, 2), true),
+            Field::new("l_discount", DataType::Decimal128(15, 2), true),
+            Field::new("l_tax", DataType::Decimal128(15, 2), true),
+            Field::new("l_returnflag", DataType::Utf8, true),
+            Field::new("l_linestatus", DataType::Utf8, true),
+            Field::new("l_shipdate", DataType::Date32, true),
+            Field::new("l_commitdate", DataType::Date32, true),
+            Field::new("l_receiptdate", DataType::Date32, true),
+            Field::new("l_shipinstruct", DataType::Utf8, true),
+            Field::new("l_shipmode", DataType::Utf8, true),
             Field::new("l_comment", DataType::Utf8, true),
         ],
         _ => unreachable!("unknown TPC-H table: {table}"),
@@ -213,12 +213,14 @@ impl TpchDataset {
 }
 
 #[async_trait]
-impl Dataset for TpchDataset {    fn create(config: &DatasetConfig) -> anyhow::Result<Arc<dyn Dataset>>
+impl Dataset for TpchDataset {
+    fn create(config: &DatasetConfig) -> anyhow::Result<Arc<dyn Dataset>>
     where
         Self: Sized + 'static,
     {
         Ok(Arc::new(Self::new(config)?))
     }
+
     fn num_batches(&self, table: &str) -> u64 {
         if !TPCH_TABLE_TIME_COLUMNS
             .iter()
@@ -226,6 +228,7 @@ impl Dataset for TpchDataset {    fn create(config: &DatasetConfig) -> anyhow::R
         {
             return 0;
         }
+
         // TPC-H produces one batch per table per step.
         u64::from(self.num_steps)
     }

--- a/crates/data-generation/src/dataset/tpch.rs
+++ b/crates/data-generation/src/dataset/tpch.rs
@@ -213,7 +213,12 @@ impl TpchDataset {
 }
 
 #[async_trait]
-impl Dataset for TpchDataset {
+impl Dataset for TpchDataset {    fn create(config: &DatasetConfig) -> anyhow::Result<Arc<dyn Dataset>>
+    where
+        Self: Sized + 'static,
+    {
+        Ok(Arc::new(Self::new(config)?))
+    }
     fn num_batches(&self, table: &str) -> u64 {
         if !TPCH_TABLE_TIME_COLUMNS
             .iter()

--- a/crates/data-generation/src/ingestor.rs
+++ b/crates/data-generation/src/ingestor.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -30,7 +31,6 @@ pub struct Ingestor {
     target: Arc<dyn Target>,
     metrics: Metrics,
     semaphore: Arc<Semaphore>,
-    batch_id: u64,
 }
 
 impl Ingestor {
@@ -40,7 +40,6 @@ impl Ingestor {
             target,
             metrics,
             semaphore: Arc::new(Semaphore::new(config.max_concurrency)),
-            batch_id: 0,
         }
     }
 
@@ -53,7 +52,7 @@ impl Ingestor {
     /// its connector and location, e.g.:
     /// `{"customer": {"connector": "s3", "location": "s3://bucket/prefix/customer/"}, ...}`
     pub async fn initialize(
-        &mut self,
+        &self,
         table_location_fn: Option<&dyn Fn(&str) -> String>,
     ) -> anyhow::Result<IngestResult> {
         // Print table locations as JSON
@@ -89,16 +88,22 @@ impl Ingestor {
 
         match self.dataset.next_batches().await {
             Ok(Some(batches)) => {
+                // Write all tables concurrently within this step.
+                let mut join_set = JoinSet::new();
                 for (table_name, batch) in batches {
                     self.metrics.record_generation();
 
-                    let start = Instant::now();
-                    let result = self
-                        .target
-                        .write(&table_name, self.batch_id, batch)
-                        .await?;
-                    self.metrics.record_write(&result, start.elapsed());
-                    self.batch_id += 1;
+                    let target = self.target.clone();
+                    let metrics = self.metrics.clone();
+                    join_set.spawn(async move {
+                        let start = Instant::now();
+                        let result = target.write(&table_name, 0, batch).await?;
+                        metrics.record_write(&result, start.elapsed());
+                        Ok::<_, anyhow::Error>(())
+                    });
+                }
+                while let Some(result) = join_set.join_next().await {
+                    result??;
                 }
             }
             Ok(None) => {
@@ -122,7 +127,7 @@ impl Ingestor {
     /// Consumes one round of batches (one per table) from the dataset without writing
     /// them to the target. This advances the dataset past the initialization records
     /// so that `run()` only processes new data.
-    pub async fn skip_initial_batches(&mut self) -> anyhow::Result<()> {
+    pub async fn skip_initial_batches(&self) -> anyhow::Result<()> {
         let table_count = self.dataset.tables().len();
 
         tracing::info!(
@@ -131,16 +136,14 @@ impl Ingestor {
         );
 
         match self.dataset.next_batches().await {
-            Ok(Some(batches)) => {
-                self.batch_id += batches.len() as u64;
-            }
+            Ok(Some(_)) => {}
             Ok(None) => {
                 tracing::warn!("Dataset exhausted before all tables were skipped");
             }
             Err(e) => return Err(e),
         }
 
-        tracing::info!(batches_skipped = self.batch_id, "Initial batches skipped");
+        tracing::info!("Initial batches skipped");
 
         Ok(())
     }
@@ -150,7 +153,7 @@ impl Ingestor {
     /// Pulls batches sequentially from the dataset and dispatches writes concurrently,
     /// bounded by the configured `max_concurrency`. This continues from wherever the
     /// dataset was left after `initialize()`.
-    pub async fn run(&mut self) -> anyhow::Result<IngestResult> {
+    pub async fn run(&self) -> anyhow::Result<IngestResult> {
         let mut join_set = JoinSet::new();
 
         // Spawn periodic metrics logger
@@ -162,6 +165,11 @@ impl Ingestor {
                 metrics_logger.log_progress();
             }
         });
+
+        let mut batch_ids = HashMap::new();
+        for table in self.dataset.tables().keys() {
+            batch_ids.insert(table.clone(), self.dataset.batch_ids(table));
+        }
 
         loop {
             let source_batches = match self.dataset.next_batches().await {
@@ -181,18 +189,23 @@ impl Ingestor {
 
                 let target = self.target.clone();
                 let metrics = self.metrics.clone();
-                let current_batch_id = self.batch_id;
-                self.batch_id += 1;
+                let next_batch_id = batch_ids
+                    .get_mut(&table_name)
+                    .and_then(|ids| ids.pop_front())
+                    .unwrap_or_else(|| {
+                        tracing::warn!(table = %table_name, "No more batch IDs available for this table");
+                        0
+                    });
 
                 join_set.spawn(async move {
                     let start = Instant::now();
-                    match target.write(&table_name, current_batch_id, batch).await {
+                    match target.write(&table_name, next_batch_id, batch).await {
                         Ok(result) => {
                             metrics.record_write(&result, start.elapsed());
                         }
                         Err(e) => {
                             metrics.record_error();
-                            tracing::error!(batch_id = current_batch_id, "Write failed: {e}");
+                            tracing::error!(batch_id = next_batch_id, "Write failed: {e}");
                         }
                     }
                     drop(permit);

--- a/crates/data-generation/src/main.rs
+++ b/crates/data-generation/src/main.rs
@@ -88,7 +88,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Command::Initialize(args) => {
-            let (mut ingestor, target) = build(&args)?;
+            let (ingestor, target) = build(&args)?;
             let loc_fn = |table: &str| target.table_s3_path(table);
             let result = ingestor.initialize(Some(&loc_fn)).await?;
 
@@ -97,7 +97,7 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Command::Run(run_args) => {
-            let (mut ingestor, _target) = build(&run_args.common)?;
+            let (ingestor, _target) = build(&run_args.common)?;
             if run_args.skip_initial {
                 ingestor.skip_initial_batches().await?;
             }

--- a/crates/data-generation/src/source/mod.rs
+++ b/crates/data-generation/src/source/mod.rs
@@ -32,7 +32,11 @@ pub trait Source: Send + Sync + 'static {
 
     /// Read a single batch from the source by its batch ID and table name.
     ///
+    /// Returns `Ok(None)` when the batch does not exist in the underlying
+    /// storage (e.g. the table has fewer batches than others). The caller
+    /// should treat this as the table having no more data.
+    ///
     /// The concrete implementation is responsible for mapping `(table_name,
     /// batch_id)` to the underlying storage path.
-    async fn read_batch(&self, table_name: &str, batch_id: u64) -> anyhow::Result<ReadResult>;
+    async fn read_batch(&self, table_name: &str, batch_id: u64) -> anyhow::Result<Option<ReadResult>>;
 }

--- a/crates/data-generation/src/source/mod.rs
+++ b/crates/data-generation/src/source/mod.rs
@@ -26,7 +26,7 @@ pub struct ReadResult {
 }
 
 #[async_trait]
-pub trait Source: Send + Sync + Clone + 'static {
+pub trait Source: Send + Sync + 'static {
     /// List available batch object paths for a given table.
     async fn list_batches(&self, table_name: &str) -> anyhow::Result<Vec<String>>;
 

--- a/crates/data-generation/src/source/s3.rs
+++ b/crates/data-generation/src/source/s3.rs
@@ -86,7 +86,7 @@ impl Source for S3Source {
         Ok(paths)
     }
 
-    async fn read_batch(&self, table_name: &str, batch_id: u64) -> anyhow::Result<ReadResult> {
+    async fn read_batch(&self, table_name: &str, batch_id: u64) -> anyhow::Result<Option<ReadResult>> {
         let location = if self.prefix.is_empty() {
             ObjectPath::from(format!("{table_name}/batch-{batch_id:06}.parquet"))
         } else {
@@ -96,7 +96,11 @@ impl Source for S3Source {
             ))
         };
 
-        let get_result = self.store.get(&location).await?;
+        let get_result = match self.store.get(&location).await {
+            Ok(r) => r,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
         let bytes = get_result.bytes().await?;
         let bytes_read = bytes.len() as u64;
 
@@ -110,10 +114,10 @@ impl Source for S3Source {
             batches.push(batch);
         }
 
-        Ok(ReadResult {
+        Ok(Some(ReadResult {
             batches,
             rows_read,
             bytes_read,
-        })
+        }))
     }
 }

--- a/crates/data-generation/src/target/mod.rs
+++ b/crates/data-generation/src/target/mod.rs
@@ -16,6 +16,8 @@ limitations under the License.
 
 pub mod s3;
 
+use std::collections::HashMap;
+
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
 
@@ -32,6 +34,8 @@ pub trait Target: Send + Sync + 'static {
         batch_id: u64,
         batch: RecordBatch,
     ) -> anyhow::Result<WriteResult>;
+
+    fn table_params(&self, table_name: &str) -> HashMap<String, serde_json::Value>;
 
     /// Returns the list of file paths/URIs that would exist after a successful
     /// generation for the given table and batch IDs.

--- a/crates/data-generation/src/target/s3.rs
+++ b/crates/data-generation/src/target/s3.rs
@@ -41,6 +41,7 @@ impl S3Target {
         let mut builder = AmazonS3Builder::from_env().with_bucket_name(&config.bucket);
 
         if let Some(region) = &config.region {
+            tracing::info!("S3 Target with region: {region}");
             builder = builder.with_region(region);
         }
         if let Some(endpoint) = &config.endpoint

--- a/crates/data-generation/src/target/s3.rs
+++ b/crates/data-generation/src/target/s3.rs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::RecordBatch;
@@ -90,6 +91,19 @@ impl Target for S3Target {
                 }
             })
             .collect()
+    }
+
+    fn table_params(&self, table_name: &str) -> HashMap<String, serde_json::Value> {
+        let mut params = HashMap::new();
+        params.insert(
+            "connector".to_string(),
+            serde_json::Value::String("s3".to_string()),
+        );
+        params.insert(
+            "location".to_string(),
+            serde_json::Value::String(self.table_s3_path(table_name)),
+        );
+        params
     }
 
     async fn write(

--- a/crates/etl/Cargo.toml
+++ b/crates/etl/Cargo.toml
@@ -12,11 +12,17 @@ version.workspace = true
 name = "etl"
 path = "src/lib.rs"
 
+[[bin]]
+name = "etl"
+path = "src/main.rs"
+
 [dependencies]
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 data-generation = { path = "../data-generation" }
 serde_json.workspace = true
+system-adapter-protocol = { path = "../system-adapter-protocol" }
 tokio.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/etl/README.md
+++ b/crates/etl/README.md
@@ -1,0 +1,5 @@
+# ETL Pipeline
+
+```bash
+cargo run -p etl -- --bucket peasee-indexes --region us-west-2 --source-prefix raw --target-prefix rehydrated --dataset tpch --scale-factor 1.0 --num-steps 10
+```

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -14,3 +14,318 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use data_generation::config::DatasetConfig as GenerationDatasetConfig;
+use data_generation::dataset::simple_sequence::SimpleSequenceDataset;
+use data_generation::dataset::tpch::TpchDataset;
+use data_generation::dataset::Dataset;
+use data_generation::source::Source;
+use data_generation::target::Target;
+use system_adapter_protocol::{DatasetConfig as ProtocolDatasetConfig, EtlType};
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+type DynSource = Arc<dyn Source>;
+type DynTarget = Arc<dyn Target>;
+
+/// Specifies which dataset implementation to use for the ETL pipeline.
+#[derive(Debug, Clone)]
+pub enum DatasetSource {
+    /// A simple auto-incrementing integer sequence dataset.
+    SimpleSequence,
+    /// The TPC-H benchmark dataset generated via DuckDB.
+    Tpch,
+}
+
+impl DatasetSource {
+    /// Create an [`Arc<dyn Dataset>`] for this source variant using the given
+    /// configuration.
+    ///
+    /// Delegates to the [`Dataset::create`] factory method on the concrete type.
+    pub fn create(
+        &self,
+        config: &GenerationDatasetConfig,
+    ) -> anyhow::Result<Arc<dyn Dataset>> {
+        match self {
+            DatasetSource::SimpleSequence => SimpleSequenceDataset::create(config),
+            DatasetSource::Tpch => TpchDataset::create(config),
+        }
+    }
+}
+
+/// The current state of an [`ETLPipeline`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PipelineState {
+    /// The pipeline has been created with a dataset, source, and target but has
+    /// not yet started processing.
+    NotStarted,
+    /// The pipeline is actively rehydrating batches (in order of batch ID) from
+    /// the configured [`Source`] into the configured [`Target`].
+    Running,
+    /// The pipeline has completed, was cancelled, or encountered an error in its
+    /// background task.
+    Stopped(StopReason),
+}
+
+/// Why the pipeline entered the [`PipelineState::Stopped`] state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopReason {
+    /// All batches for every table were processed successfully.
+    Completed,
+    /// The pipeline was cancelled via its [`CancellationToken`].
+    Cancelled,
+    /// The background task encountered an unrecoverable error.
+    Error(String),
+}
+
+/// An ETL pipeline that reads batches from a [`Source`], rehydrates them using a
+/// [`Dataset`], and writes them to a [`Target`].
+///
+/// # Lifecycle
+///
+/// 1. **[`NotStarted`](PipelineState::NotStarted)** — created via [`ETLPipeline::new`]
+///    with a dataset, source, and target. Call [`setup_request_datasets`](ETLPipeline::setup_request_datasets)
+///    to obtain the dataset configurations that a system adapter needs.
+/// 2. **[`Running`](PipelineState::Running)** — the pipeline is actively processing
+///    batches.
+/// 3. **[`Stopped`](PipelineState::Stopped)** — the pipeline finished, was cancelled,
+///    or hit an error.
+pub struct ETLPipeline {
+    dataset_source: DatasetSource,
+    dataset: Arc<dyn Dataset>,
+    source: DynSource,
+    target: DynTarget,
+    state_rx: watch::Receiver<PipelineState>,
+    state_tx: Arc<watch::Sender<PipelineState>>,
+    cancel_token: CancellationToken,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ETLPipeline {
+    /// Creates a new ETL pipeline in the [`PipelineState::NotStarted`] state.
+    ///
+    /// The `dataset_source` selects which [`Dataset`] implementation to use,
+    /// and `config` is forwarded to the [`Dataset::create`] factory method to
+    /// build the dataset instance.
+    pub fn new(
+        dataset_source: DatasetSource,
+        config: &GenerationDatasetConfig,
+        source: DynSource,
+        target: DynTarget,
+    ) -> anyhow::Result<Self> {
+        let dataset = dataset_source.create(config)?;
+        let (state_tx, state_rx) = watch::channel(PipelineState::NotStarted);
+        Ok(Self {
+            dataset_source,
+            dataset,
+            source,
+            target,
+            state_rx,
+            state_tx: Arc::new(state_tx),
+            cancel_token: CancellationToken::new(),
+            handle: None,
+        })
+    }
+
+    /// Returns the current state of the pipeline.
+    pub fn state(&self) -> PipelineState {
+        self.state_rx.borrow().clone()
+    }
+
+    /// Returns a [`watch::Receiver`] that can be used to observe state changes.
+    pub fn state_watch(&self) -> watch::Receiver<PipelineState> {
+        self.state_rx.clone()
+    }
+
+    /// Returns the [`DatasetSource`] variant this pipeline was created with.
+    pub fn dataset_source(&self) -> &DatasetSource {
+        &self.dataset_source
+    }
+
+    /// Returns the underlying [`Dataset`] trait object.
+    pub fn dataset(&self) -> &Arc<dyn Dataset> {
+        &self.dataset
+    }
+
+    /// Returns the [`CancellationToken`] for this pipeline.
+    ///
+    /// Cancelling this token will cause the background task to stop after the
+    /// current batch finishes and transition the pipeline to
+    /// [`PipelineState::Stopped(StopReason::Cancelled)`].
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// Cancels the pipeline if it is running.
+    pub fn cancel(&self) {
+        self.cancel_token.cancel();
+    }
+
+    /// Returns the dataset configurations required to set up the system adapter.
+    ///
+    /// Each entry maps a table name to its
+    /// [`DatasetConfig`](system_adapter_protocol::DatasetConfig), which includes
+    /// the rehydrated Arrow schema and the ETL type. This can be used to build a
+    /// [`SetupRequest`](system_adapter_protocol::SetupRequest) for the system
+    /// adapter.
+    pub fn setup_request_datasets(&self) -> HashMap<String, ProtocolDatasetConfig> {
+        self.dataset
+            .tables()
+            .into_iter()
+            .map(|(name, table)| {
+                let config = ProtocolDatasetConfig {
+                    etl_type: EtlType::S3,
+                    schema: table.rehydrated_schema(),
+                    params: HashMap::new(),
+                };
+                (name, config)
+            })
+            .collect()
+    }
+
+    /// Starts the ETL pipeline, transitioning from [`PipelineState::NotStarted`]
+    /// to [`PipelineState::Running`].
+    ///
+    /// Spawns a background tokio task that iterates over every table and
+    /// processes batch IDs in ascending order. For each batch the task:
+    ///
+    /// 1. Reads the batch from the [`Source`].
+    /// 2. Rehydrates it through the [`Dataset`] (appending time columns, etc.).
+    /// 3. Writes the rehydrated batch to the [`Target`].
+    ///
+    /// The task transitions to [`PipelineState::Stopped`] when all batches are
+    /// processed, the [`CancellationToken`] is triggered, or an error occurs.
+    ///
+    /// Returns an error if the pipeline is not in the [`NotStarted`] state.
+    pub fn start(&mut self) -> anyhow::Result<()> {
+        if *self.state_rx.borrow() != PipelineState::NotStarted {
+            anyhow::bail!(
+                "Cannot start pipeline: current state is {:?}",
+                *self.state_rx.borrow()
+            );
+        }
+
+        let _ = self.state_tx.send(PipelineState::Running);
+
+        let dataset = Arc::clone(&self.dataset);
+        let source = Arc::clone(&self.source);
+        let target = Arc::clone(&self.target);
+        let cancel = self.cancel_token.clone();
+        let state_tx = Arc::clone(&self.state_tx);
+
+        // Build the ordered work plan: Vec<(table_name, batch_id)> sorted by
+        // batch_id so all tables advance together.
+        let tables = dataset.tables();
+        let mut work: Vec<(String, u64)> = Vec::new();
+        for (name, _) in &tables {
+            for id in dataset.batch_ids(name) {
+                work.push((name.clone(), id));
+            }
+        }
+        work.sort_by_key(|(_, id)| *id);
+
+        let handle = tokio::spawn(async move {
+            let reason = run_pipeline(dataset, source, target, work, cancel).await;
+            let _ = state_tx.send(PipelineState::Stopped(reason));
+        });
+
+        self.handle = Some(handle);
+        Ok(())
+    }
+
+    /// Waits for the pipeline background task to finish and returns the final
+    /// [`PipelineState`].
+    ///
+    /// If the pipeline has not been started, this returns immediately with the
+    /// current state.
+    pub async fn wait(mut self) -> PipelineState {
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+        self.state()
+    }
+}
+
+/// Core loop executed inside the spawned task.
+///
+/// Processes `work` items sequentially, checking for cancellation between each
+/// batch.
+async fn run_pipeline(
+    dataset: Arc<dyn Dataset>,
+    source: DynSource,
+    target: DynTarget,
+    work: Vec<(String, u64)>,
+    cancel: CancellationToken,
+) -> StopReason {
+    let total = work.len();
+    info!(total_batches = total, "ETL pipeline started");
+
+    for (idx, (table_name, batch_id)) in work.into_iter().enumerate() {
+        if cancel.is_cancelled() {
+            warn!("ETL pipeline cancelled at batch {idx}/{total}");
+            return StopReason::Cancelled;
+        }
+
+        // 1. Read from source
+        let read_result = match source.read_batch(&table_name, batch_id).await {
+            Ok(r) => r,
+            Err(e) => {
+                error!(
+                    table = %table_name,
+                    batch_id,
+                    error = %e,
+                    "Failed to read batch from source"
+                );
+                return StopReason::Error(format!(
+                    "read {table_name} batch {batch_id}: {e}"
+                ));
+            }
+        };
+
+        // 2. Rehydrate each record batch and write to target
+        for batch in read_result.batches {
+            let rehydrated = match dataset.rehydrate(&table_name, &batch) {
+                Ok(b) => b,
+                Err(e) => {
+                    error!(
+                        table = %table_name,
+                        batch_id,
+                        error = %e,
+                        "Failed to rehydrate batch"
+                    );
+                    return StopReason::Error(format!(
+                        "rehydrate {table_name} batch {batch_id}: {e}"
+                    ));
+                }
+            };
+
+            // 3. Write to target
+            if let Err(e) = target.write(&table_name, batch_id, rehydrated).await {
+                error!(
+                    table = %table_name,
+                    batch_id,
+                    error = %e,
+                    "Failed to write batch to target"
+                );
+                return StopReason::Error(format!(
+                    "write {table_name} batch {batch_id}: {e}"
+                ));
+            }
+        }
+
+        info!(
+            table = %table_name,
+            batch_id,
+            progress = format!("{}/{}", idx + 1, total),
+            "Batch processed"
+        );
+    }
+
+    info!("ETL pipeline completed successfully");
+    StopReason::Completed
+}
+

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -181,7 +181,7 @@ impl ETLPipeline {
                 let config = ProtocolDatasetConfig {
                     etl_type: EtlType::S3,
                     schema: table.rehydrated_schema(),
-                    params: HashMap::new(),
+                    params: self.target.table_params(&name),
                 };
                 (name, config)
             })

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -25,8 +25,9 @@ use data_generation::source::Source;
 use data_generation::target::Target;
 use system_adapter_protocol::{DatasetConfig as ProtocolDatasetConfig, EtlType};
 use tokio::sync::watch;
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 use tokio_util::sync::CancellationToken;
+use std::collections::{BTreeMap, HashSet};
 use tracing::{error, info, warn};
 
 type DynSource = Arc<dyn Source>;
@@ -252,8 +253,8 @@ impl ETLPipeline {
 
 /// Core loop executed inside the spawned task.
 ///
-/// Processes `work` items sequentially, checking for cancellation between each
-/// batch.
+/// Groups work items by batch ID and processes all tables within each step
+/// concurrently, checking for cancellation between steps.
 async fn run_pipeline(
     dataset: Arc<dyn Dataset>,
     source: DynSource,
@@ -261,67 +262,126 @@ async fn run_pipeline(
     work: Vec<(String, u64)>,
     cancel: CancellationToken,
 ) -> StopReason {
-    let total = work.len();
-    info!(total_batches = total, "ETL pipeline started");
+    // Group work by batch_id so all tables in a step run in parallel.
+    let mut steps: BTreeMap<u64, Vec<String>> = BTreeMap::new();
+    for (table_name, batch_id) in &work {
+        steps.entry(*batch_id).or_default().push(table_name.clone());
+    }
 
-    for (idx, (table_name, batch_id)) in work.into_iter().enumerate() {
+    let total_steps = steps.len();
+    let total_batches = work.len();
+    info!(total_steps, total_batches, "ETL pipeline started");
+
+    // Tables whose data has been fully consumed (source returned `None`).
+    let mut finished_tables: HashSet<String> = HashSet::new();
+
+    for (step_idx, (batch_id, tables)) in steps.into_iter().enumerate() {
         if cancel.is_cancelled() {
-            warn!("ETL pipeline cancelled at batch {idx}/{total}");
+            warn!("ETL pipeline cancelled at step {step_idx}/{total_steps}");
             return StopReason::Cancelled;
         }
 
-        // 1. Read from source
-        let read_result = match source.read_batch(&table_name, batch_id).await {
-            Ok(r) => r,
-            Err(e) => {
-                error!(
-                    table = %table_name,
-                    batch_id,
-                    error = %e,
-                    "Failed to read batch from source"
-                );
-                return StopReason::Error(format!(
-                    "read {table_name} batch {batch_id}: {e}"
-                ));
-            }
-        };
+        // Filter out tables that have already been fully consumed.
+        let active_tables: Vec<String> = tables
+            .into_iter()
+            .filter(|t| !finished_tables.contains(t))
+            .collect();
 
-        // 2. Rehydrate each record batch and write to target
-        for batch in read_result.batches {
-            let rehydrated = match dataset.rehydrate(&table_name, &batch) {
-                Ok(b) => b,
-                Err(e) => {
-                    error!(
-                        table = %table_name,
-                        batch_id,
-                        error = %e,
-                        "Failed to rehydrate batch"
-                    );
-                    return StopReason::Error(format!(
-                        "rehydrate {table_name} batch {batch_id}: {e}"
-                    ));
+        if active_tables.is_empty() {
+            continue;
+        }
+
+        // Process all tables for this batch_id concurrently.
+        let mut join_set: JoinSet<Result<(String, bool), String>> = JoinSet::new();
+        for table_name in active_tables {
+            let dataset = Arc::clone(&dataset);
+            let source = Arc::clone(&source);
+            let target = Arc::clone(&target);
+
+            join_set.spawn(async move {
+                // 1. Read from source
+                let read_result = match source.read_batch(&table_name, batch_id).await {
+                    Ok(Some(r)) => r,
+                    Ok(None) => {
+                        info!(
+                            table = %table_name,
+                            batch_id,
+                            "No more batches for table, marking as finished"
+                        );
+                        return Ok((table_name, true)); // mark as finished
+                    }
+                    Err(e) => {
+                        error!(
+                            table = %table_name,
+                            batch_id,
+                            error = %e,
+                            "Failed to read batch from source"
+                        );
+                        return Err(format!("read {table_name} batch {batch_id}: {e}"));
+                    }
+                };
+
+                // 2. Rehydrate each record batch and write to target
+                for batch in read_result.batches {
+                    let rehydrated = match dataset.rehydrate(&table_name, &batch) {
+                        Ok(b) => b,
+                        Err(e) => {
+                            error!(
+                                table = %table_name,
+                                batch_id,
+                                error = %e,
+                                "Failed to rehydrate batch"
+                            );
+                            return Err(format!(
+                                "rehydrate {table_name} batch {batch_id}: {e}"
+                            ));
+                        }
+                    };
+
+                    // 3. Write to target
+                    if let Err(e) = target.write(&table_name, batch_id, rehydrated).await {
+                        error!(
+                            table = %table_name,
+                            batch_id,
+                            error = %e,
+                            "Failed to write batch to target"
+                        );
+                        return Err(format!(
+                            "write {table_name} batch {batch_id}: {e}"
+                        ));
+                    }
                 }
-            };
 
-            // 3. Write to target
-            if let Err(e) = target.write(&table_name, batch_id, rehydrated).await {
-                error!(
+                info!(
                     table = %table_name,
                     batch_id,
-                    error = %e,
-                    "Failed to write batch to target"
+                    "Table batch processed"
                 );
-                return StopReason::Error(format!(
-                    "write {table_name} batch {batch_id}: {e}"
-                ));
+                Ok((table_name, false)) // not finished
+            });
+        }
+
+        // Collect results from all concurrent table tasks in this step.
+        while let Some(result) = join_set.join_next().await {
+            match result {
+                Ok(Ok((table_name, is_finished))) => {
+                    if is_finished {
+                        finished_tables.insert(table_name);
+                    }
+                }
+                Ok(Err(err_msg)) => {
+                    return StopReason::Error(err_msg);
+                }
+                Err(e) => {
+                    return StopReason::Error(format!("Task panicked: {e}"));
+                }
             }
         }
 
         info!(
-            table = %table_name,
             batch_id,
-            progress = format!("{}/{}", idx + 1, total),
-            "Batch processed"
+            progress = format!("{}/{}", step_idx + 1, total_steps),
+            "Step completed"
         );
     }
 

--- a/crates/etl/src/main.rs
+++ b/crates/etl/src/main.rs
@@ -35,7 +35,7 @@ struct Cli {
     scale_factor: f64,
 
     /// Number of data generation steps (partitions)
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 25)]
     num_steps: u16,
 
     /// S3 bucket name (used for both source and target)

--- a/crates/etl/src/main.rs
+++ b/crates/etl/src/main.rs
@@ -1,0 +1,150 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use std::sync::Arc;
+
+use clap::Parser;
+use data_generation::config::{DatasetConfig, TargetConfig};
+use data_generation::source::s3::S3Source;
+use data_generation::target::s3::S3Target;
+use etl::{DatasetSource, ETLPipeline, PipelineState, StopReason};
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser)]
+#[command(about = "Run an ETL pipeline that reads from S3, rehydrates data, and writes back to S3")]
+struct Cli {
+    /// Dataset type: "tpch" or "simple_sequence"
+    #[arg(long, default_value = "tpch")]
+    dataset: String,
+
+    /// Scale factor for data generation
+    #[arg(long, default_value_t = 1.0)]
+    scale_factor: f64,
+
+    /// Number of data generation steps (partitions)
+    #[arg(long, default_value_t = 100)]
+    num_steps: u16,
+
+    /// S3 bucket name (used for both source and target)
+    #[arg(long)]
+    bucket: String,
+
+    /// S3 key prefix for source data
+    #[arg(long, default_value = "")]
+    source_prefix: String,
+
+    /// S3 key prefix for target (rehydrated) data
+    #[arg(long, default_value = "")]
+    target_prefix: String,
+
+    /// AWS region
+    #[arg(long)]
+    region: Option<String>,
+
+    /// S3 endpoint URL (for MinIO/LocalStack)
+    #[arg(long)]
+    endpoint: Option<String>,
+}
+
+impl Cli {
+    fn dataset_source(&self) -> anyhow::Result<DatasetSource> {
+        match self.dataset.as_str() {
+            "tpch" => Ok(DatasetSource::Tpch),
+            "simple_sequence" => Ok(DatasetSource::SimpleSequence),
+            other => anyhow::bail!("Unknown dataset type: {other}. Use 'tpch' or 'simple_sequence'."),
+        }
+    }
+
+    fn dataset_config(&self) -> DatasetConfig {
+        DatasetConfig {
+            dataset_type: self.dataset.clone(),
+            scale_factor: self.scale_factor,
+            num_steps: self.num_steps,
+        }
+    }
+
+    fn source_config(&self) -> TargetConfig {
+        TargetConfig {
+            bucket: self.bucket.clone(),
+            prefix: self.source_prefix.clone(),
+            region: self.region.clone(),
+            endpoint: self.endpoint.clone(),
+        }
+    }
+
+    fn target_config(&self) -> TargetConfig {
+        TargetConfig {
+            bucket: self.bucket.clone(),
+            prefix: self.target_prefix.clone(),
+            region: self.region.clone(),
+            endpoint: self.endpoint.clone(),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let cli = Cli::parse();
+
+    let dataset_source = cli.dataset_source()?;
+    let dataset_config = cli.dataset_config();
+
+    let source = Arc::new(S3Source::new(&cli.source_config())?);
+    let target = Arc::new(S3Target::new(&cli.target_config())?);
+
+    let mut pipeline = ETLPipeline::new(dataset_source, &dataset_config, source, target)?;
+
+    tracing::info!(
+        dataset = %cli.dataset,
+        bucket = %cli.bucket,
+        source_prefix = %cli.source_prefix,
+        target_prefix = %cli.target_prefix,
+        scale_factor = cli.scale_factor,
+        num_steps = cli.num_steps,
+        "Starting ETL pipeline"
+    );
+
+    // Log the tables and schemas that will be processed.
+    let datasets = pipeline.setup_request_datasets();
+    for (name, config) in &datasets {
+        tracing::info!(table = %name, schema = ?config.schema, "Dataset table registered");
+    }
+
+    pipeline.start()?;
+
+    let final_state = pipeline.wait().await;
+    match &final_state {
+        PipelineState::Stopped(StopReason::Completed) => {
+            tracing::info!("ETL pipeline completed successfully");
+        }
+        PipelineState::Stopped(StopReason::Cancelled) => {
+            tracing::warn!("ETL pipeline was cancelled");
+        }
+        PipelineState::Stopped(StopReason::Error(e)) => {
+            tracing::error!(error = %e, "ETL pipeline stopped with error");
+            anyhow::bail!("ETL pipeline failed: {e}");
+        }
+        other => {
+            anyhow::bail!("Unexpected final pipeline state: {other:?}");
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Implements better schema validation output for data generator
* Implements the ETL pipeline for loading and completing datasets

API consumers would configure an ETL pipeline based on an input `DatasetSource::{variant}` and a configured `Source` and `Target`.

With a configured pipeline, consumers can call `setup_requests_datasets` to retrieve the datasets for use with the system adapter protocol to construct a setup request.