### PR TITLE
Add workflow to build and cache spicebench on trunk merges

### DIFF
--- a/.github/actions/build-spicebench/action.yml
+++ b/.github/actions/build-spicebench/action.yml
@@ -1,0 +1,44 @@
+name: "Build spicebench"
+description: "Builds spicebench and caches the binary. Restores from cache if available."
+
+inputs:
+  lookup-only:
+    description: "Only check if the cache exists, don't restore the binary"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore spicebench cache
+      id: cache-spicebench
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.spice/bin/spicebench
+        key: spicebench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
+        restore-keys: |
+          spicebench-${{ runner.os }}-
+        lookup-only: ${{ inputs.lookup-only }}
+
+    - name: Setup Rust toolchain
+      if: steps.cache-spicebench.outputs.cache-hit != 'true'
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: 1.91
+        cache: true
+
+    - name: Build spicebench
+      id: build-spicebench
+      if: steps.cache-spicebench.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        mkdir -p ~/.spice/bin
+        cargo build -p spicebench
+        install -m 755 target/debug/spicebench ~/.spice/bin/spicebench
+
+    - name: Save spicebench cache
+      if: steps.build-spicebench.outcome == 'success'
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.spice/bin/spicebench
+        key: spicebench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}

--- a/.github/workflows/cache_spicebench.yml
+++ b/.github/workflows/cache_spicebench.yml
@@ -13,31 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check spicebench cache
-        id: cache-spicebench
-        uses: actions/cache/restore@v4
+      - uses: ./.github/actions/build-spicebench
         with:
-          path: ~/.spice/bin/spicebench
-          key: spicebench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
-          lookup-only: true
-
-      - name: Setup Rust toolchain
-        if: steps.cache-spicebench.outputs.cache-hit != 'true'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 1.91
-          cache: true
-
-      - name: Build spicebench
-        if: steps.cache-spicebench.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.spice/bin
-          cargo build -p spicebench
-          install -m 755 target/debug/spicebench ~/.spice/bin/spicebench
-
-      - name: Save spicebench cache
-        if: steps.cache-spicebench.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.spice/bin/spicebench
-          key: spicebench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
+          lookup-only: "true"

--- a/.github/workflows/cache_spicebench.yml
+++ b/.github/workflows/cache_spicebench.yml
@@ -1,0 +1,43 @@
+name: Cache spicebench
+
+on:
+  push:
+    branches:
+      - trunk
+
+jobs:
+  build-and-cache:
+    name: Build and cache spicebench
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check spicebench cache
+        id: cache-spicebench
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.spice/bin/spicebench
+          key: spicebench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
+          lookup-only: true
+
+      - name: Setup Rust toolchain
+        if: steps.cache-spicebench.outputs.cache-hit != 'true'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.91
+          cache: true
+
+      - name: Build spicebench
+        if: steps.cache-spicebench.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.spice/bin
+          cargo build -p spicebench
+          install -m 755 target/debug/spicebench ~/.spice/bin/spicebench
+
+      - name: Save spicebench cache
+        if: steps.cache-spicebench.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.spice/bin/spicebench
+          key: spicebench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}

--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -89,36 +89,7 @@ jobs:
       - name: pull spidapter image
         run: docker pull ghcr.io/spiceai/spidapter:latest
 
-      - name: Restore spicebench cache
-        id: cache-spicebench
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.spice/bin/spicebench
-          key: spicebench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
-          restore-keys: |
-            spicebench-${{ runner.os }}-
-
-      - name: Setup Rust toolchain
-        if: steps.cache-spicebench.outputs.cache-hit != 'true'
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 1.91
-          cache: true
-
-      - name: Build spicebench
-        id: build-spicebench
-        if: steps.cache-spicebench.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.spice/bin
-          cargo build -p spicebench
-          install -m 755 target/debug/spicebench ~/.spice/bin/spicebench
-
-      - name: Save spicebench cache
-        if: steps.build-spicebench.outcome == 'success'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.spice/bin/spicebench
-          key: spicebench-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml', '**/*.rs') }}
+      - uses: ./.github/actions/build-spicebench
 
       - name: Install ADBC FlightSQL driver
         run: |


### PR DESCRIPTION
## Summary
- Adds a new `cache_spicebench.yml` workflow triggered on pushes to `trunk`
- Pre-builds and caches `spicebench` using the same cache key as `run_spicebench.yml`
- Skips the build if the cache already exists (`lookup-only: true`)

This ensures `run_spicebench.yml` gets cache hits after each merge, avoiding redundant ~30min Rust builds.

## Test plan
- [ ] Merge to trunk and verify the workflow runs and caches the binary
- [ ] Run `run_spicebench.yml` and confirm it gets a cache hit on the restore step