### PR TITLE
chore: auto-fix fmt + clippy in PR CI instead of failing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,14 +55,19 @@ jobs:
       - name: cargo test
         run: make test
 
-  fmt:
-    name: cargo fmt check
+  lint-fix:
+    name: cargo fmt + clippy fix
     runs-on: spiceai-macos
     timeout-minutes: 60
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && github.event_name == 'pull_request'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -70,23 +75,14 @@ jobs:
           toolchain: 1.91
           cache: false # Using GHA cache is slower than re-installing
 
-      - name: cargo fmt check
-        run: make fmt-check
+      - name: cargo fmt + clippy fix
+        run: make fix
 
-  clippy:
-    name: cargo clippy
-    runs-on: spiceai-macos
-    timeout-minutes: 60
-    needs: changes
-    if: needs.changes.outputs.rust == 'true'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 1.91
-          cache: false # Using GHA cache is slower than re-installing
-
-      - name: cargo clippy
-        run: make clippy
+      - name: Commit fixes
+        run: |
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: auto-fix cargo fmt + clippy"
+          git push


### PR DESCRIPTION
## Summary
- Replace separate `fmt-check` and `clippy` jobs with a single `lint-fix` job
- Runs `make fix` (fmt + clippy --fix) and commits any changes back to the PR branch
- No-ops cleanly if there are no changes to fix

## Test plan
- [ ] Open a PR with a formatting issue and verify the bot commits a fix
- [ ] Open a clean PR and verify the job passes without committing