### PR TITLE
fix: Move TableFormat into spicebench

### DIFF
--- a/crates/data-generation/src/config.rs
+++ b/crates/data-generation/src/config.rs
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(about = "Spice.ai data generation tool - generates Arrow data and writes to S3")]
@@ -63,14 +63,6 @@ pub struct CommonArgs {
     #[arg(long, default_value = "")]
     pub prefix: String,
 
-    /// Logical table format propagated to system adapters
-    #[arg(long, value_enum, default_value = "parquet")]
-    pub table_format: TableFormat,
-
-    /// Executor instance type label propagated to adapters for dashboarding
-    #[arg(long, default_value = "unknown")]
-    pub executor_instance_type: String,
-
     /// AWS region
     #[arg(long)]
     pub region: Option<String>,
@@ -93,29 +85,8 @@ pub struct DatasetConfig {
 pub struct TargetConfig {
     pub bucket: String,
     pub prefix: String,
-    pub table_format: TableFormat,
-    pub executor_instance_type: String,
     pub region: Option<String>,
     pub endpoint: Option<String>,
-}
-
-#[derive(Clone, Debug, ValueEnum)]
-#[value(rename_all = "lower")]
-pub enum TableFormat {
-    Iceberg,
-    Parquet,
-    Delta,
-}
-
-impl std::fmt::Display for TableFormat {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value = match self {
-            Self::Iceberg => "iceberg",
-            Self::Parquet => "parquet",
-            Self::Delta => "delta",
-        };
-        write!(f, "{value}")
-    }
 }
 
 pub struct IngestorConfig {
@@ -135,8 +106,6 @@ impl CommonArgs {
         TargetConfig {
             bucket: self.bucket.clone(),
             prefix: self.prefix.clone(),
-            table_format: self.table_format.clone(),
-            executor_instance_type: self.executor_instance_type.clone(),
             region: self.region.clone(),
             endpoint: self.endpoint.clone(),
         }

--- a/crates/etl/src/main.rs
+++ b/crates/etl/src/main.rs
@@ -17,7 +17,7 @@ limitations under the License.
 use std::sync::Arc;
 
 use clap::Parser;
-use data_generation::config::{DatasetConfig, TableFormat, TargetConfig};
+use data_generation::config::{DatasetConfig, TargetConfig};
 use data_generation::storage::s3::S3Storage;
 use etl::{DatasetSource, ETLPipeline, PipelineState, StopReason};
 use tracing_subscriber::EnvFilter;
@@ -49,14 +49,6 @@ struct Cli {
     /// A random suffix is appended automatically to create a unique destination per run.
     #[arg(long, default_value = "")]
     target_base_prefix: String,
-
-    /// Logical table format propagated to system adapters
-    #[arg(long, value_enum, default_value = "parquet")]
-    table_format: TableFormat,
-
-    /// Executor instance type label propagated to adapters for dashboarding
-    #[arg(long, default_value = "unknown")]
-    executor_instance_type: String,
 
     /// AWS region
     #[arg(long)]
@@ -90,8 +82,6 @@ impl Cli {
         TargetConfig {
             bucket: self.bucket.clone(),
             prefix: self.source_prefix.clone(),
-            table_format: self.table_format.clone(),
-            executor_instance_type: self.executor_instance_type.clone(),
             region: self.region.clone(),
             endpoint: self.endpoint.clone(),
         }
@@ -107,8 +97,6 @@ impl Cli {
         TargetConfig {
             bucket: self.bucket.clone(),
             prefix,
-            table_format: self.table_format.clone(),
-            executor_instance_type: self.executor_instance_type.clone(),
             region: self.region.clone(),
             endpoint: self.endpoint.clone(),
         }

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -15,10 +15,28 @@ limitations under the License.
 */
 
 use clap::{ArgAction, Parser, ValueEnum};
-use data_generation::config::TableFormat;
 
 mod dataset;
 use crate::scenario::Scenario;
+
+#[derive(Clone, Debug, ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum TableFormat {
+    Iceberg,
+    Parquet,
+    Delta,
+}
+
+impl std::fmt::Display for TableFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::Iceberg => "iceberg",
+            Self::Parquet => "parquet",
+            Self::Delta => "delta",
+        };
+        write!(f, "{value}")
+    }
+}
 
 /// Arguments Common to all [`TestCommands`].
 #[derive(Parser, Debug, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,10 +117,16 @@ async fn main() -> anyhow::Result<()> {
     // --- Setup the system adapter (target already has initial data) ---
     let run_id = Uuid::new_v4();
     let datasets = pipeline.setup_request_datasets();
-    let setup_metadata = std::collections::HashMap::from([(
-        "executor_instance_type".to_string(),
-        serde_json::Value::String(cli.common.executor_instance_type.clone()),
-    ), ("table_format".to_string(), serde_json::Value::String(cli.common.table_format.to_string()))]);
+    let setup_metadata = std::collections::HashMap::from([
+        (
+            "executor_instance_type".to_string(),
+            serde_json::Value::String(cli.common.executor_instance_type.clone()),
+        ),
+        (
+            "table_format".to_string(),
+            serde_json::Value::String(cli.common.table_format.to_string()),
+        ),
+    ]);
 
     if let Err(e) = system_adapter_client
         .setup(run_id, datasets, setup_metadata)

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,6 @@ async fn main() -> anyhow::Result<()> {
         prefix: cli.common.etl_source_prefix.clone(),
         region: cli.common.etl_region.clone(),
         endpoint: cli.common.etl_endpoint.clone(),
-        table_format: cli.common.table_format.clone(),
-        executor_instance_type: cli.common.executor_instance_type.clone(),
     };
 
     let run_suffix = Uuid::new_v4().to_string();
@@ -96,8 +94,6 @@ async fn main() -> anyhow::Result<()> {
         prefix: target_prefix,
         region: cli.common.etl_region.clone(),
         endpoint: cli.common.etl_endpoint.clone(),
-        table_format: cli.common.table_format.clone(),
-        executor_instance_type: cli.common.executor_instance_type.clone(),
     };
 
     let source = Arc::new(S3Storage::new(&source_config)?);
@@ -124,7 +120,7 @@ async fn main() -> anyhow::Result<()> {
     let setup_metadata = std::collections::HashMap::from([(
         "executor_instance_type".to_string(),
         serde_json::Value::String(cli.common.executor_instance_type.clone()),
-    )]);
+    ), ("table_format".to_string(), serde_json::Value::String(cli.common.table_format.to_string()))]);
 
     if let Err(e) = system_adapter_client
         .setup(run_id, datasets, setup_metadata)


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Moves `TableFormat` into spicebench instead of data generator