### PR TITLE
ci: pass AWS credentials to spidapter Docker container

### DIFF
--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -254,7 +254,7 @@ jobs:
             fi
           else
             ADAPTER_CMD="docker"
-            ADAPTER_ARGS="run -i -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL ghcr.io/spiceai/spidapter:latest stdio --verbose"
+            ADAPTER_ARGS="run -i -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY ghcr.io/spiceai/spidapter:latest stdio --verbose"
             ADAPTER_ENVS=""
           fi
 


### PR DESCRIPTION
Pass `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables into the spidapter Docker container so the Iceberg Glue catalog can resolve `${secrets:AWS_ACCESS_KEY_ID}` and `${secrets:AWS_SECRET_ACCESS_KEY}` references in the spicepod.

Without this, the AWS credentials are available in the GitHub Actions job environment but never forwarded into the container, causing Glue catalog authentication to fail.