### PR TITLE
Update e2e latency metric to use current `created_at` instead of `now()`

### DIFF
--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -646,9 +646,15 @@ impl ETLPipeline {
         let last_created_at = Arc::clone(&self.last_created_at_us);
 
         let handle = tokio::spawn(async move {
-            let outcome =
-                run_pipeline(source, target, work_state, cancel, step_limit, last_created_at)
-                    .await;
+            let outcome = run_pipeline(
+                source,
+                target,
+                work_state,
+                cancel,
+                step_limit,
+                last_created_at,
+            )
+            .await;
             let _ = state_tx.send(outcome);
         });
 

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -29,7 +29,7 @@ use data_generation::storage::DataStorage;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc as StdArc;
 use std::sync::Mutex as StdMutex;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::time::Instant;
 use system_adapter_protocol::DatasetConfig as ProtocolDatasetConfig;
 use tokio::sync::watch;
@@ -59,12 +59,16 @@ fn schema_with_created_at(schema: &SchemaRef) -> SchemaRef {
 }
 
 /// Appends a `__created_at` column (current wall-clock time, microsecond UTC)
-/// to the given batch.
-fn append_created_at(batch: &RecordBatch) -> anyhow::Result<RecordBatch> {
+/// to the given batch and stores the value in `last_created_at`.
+fn append_created_at(
+    batch: &RecordBatch,
+    last_created_at: &AtomicI64,
+) -> anyhow::Result<RecordBatch> {
     let now_us = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system time before UNIX epoch")
         .as_micros() as i64;
+    last_created_at.store(now_us, Ordering::Relaxed);
 
     let timestamps =
         TimestampMicrosecondArray::from(vec![Some(now_us); batch.num_rows()]).with_timezone("UTC");
@@ -317,6 +321,9 @@ pub struct ETLPipeline {
     batch_budget: Option<usize>,
     /// Shared work state handed between the pipeline and its background task.
     work_state: Arc<StdMutex<PipelineWorkState>>,
+    /// Per-table most recent `__created_at` timestamp (microseconds UTC)
+    /// written by the pipeline.  Updated atomically by [`append_created_at`].
+    last_created_at_us: Arc<HashMap<String, AtomicI64>>,
 }
 
 impl ETLPipeline {
@@ -333,6 +340,13 @@ impl ETLPipeline {
         mutations: &MutationConfig,
     ) -> anyhow::Result<Self> {
         let dataset = dataset_source.create(config, mutations, Arc::clone(&data_storage))?;
+        let last_created_at_us = Arc::new(
+            dataset
+                .tables()
+                .keys()
+                .map(|name| (name.clone(), AtomicI64::new(0)))
+                .collect(),
+        );
         let (state_tx, state_rx) = watch::channel(PipelineState::NotStarted);
         Ok(Self {
             dataset_source,
@@ -348,6 +362,7 @@ impl ETLPipeline {
                 steps: BTreeMap::new(),
                 finished_tables: HashSet::new(),
             })),
+            last_created_at_us,
         })
     }
 
@@ -369,6 +384,12 @@ impl ETLPipeline {
     /// Returns the underlying [`Dataset`] trait object.
     pub fn dataset(&self) -> &Arc<dyn Dataset> {
         &self.dataset
+    }
+
+    /// Returns a shared handle to the per-table most recent `__created_at`
+    /// timestamps (microseconds UTC) written by the pipeline.
+    pub fn last_created_at_us(&self) -> Arc<HashMap<String, AtomicI64>> {
+        Arc::clone(&self.last_created_at_us)
     }
 
     /// Returns the [`CancellationToken`] for this pipeline.
@@ -429,6 +450,7 @@ impl ETLPipeline {
         for table_name in tables.keys() {
             let source = Arc::clone(&self.data_storage);
             let target = Arc::clone(&self.data_sink);
+            let last_created_at = Arc::clone(&self.last_created_at_us);
             let table_name = table_name.clone();
 
             join_set.spawn(async move {
@@ -448,10 +470,14 @@ impl ETLPipeline {
                     })?;
 
                     for segment in segments {
-                        let rehydrated = append_created_at(&segment.batch).map_err(|e| {
-                            format!(
-                                "append __created_at to {table_name} batch {first_batch_id}: {e}"
-                            )
+                        let tracker = last_created_at
+                            .get(&table_name)
+                            .expect("table missing from last_created_at map");
+                        let rehydrated =
+                            append_created_at(&segment.batch, tracker).map_err(|e| {
+                                format!(
+                                    "append __created_at to {table_name} batch {first_batch_id}: {e}"
+                                )
                         })?;
 
                         target
@@ -617,9 +643,12 @@ impl ETLPipeline {
         let cancel = self.cancel_token.clone();
         let state_tx = Arc::clone(&self.state_tx);
         let work_state = Arc::clone(&self.work_state);
+        let last_created_at = Arc::clone(&self.last_created_at_us);
 
         let handle = tokio::spawn(async move {
-            let outcome = run_pipeline(source, target, work_state, cancel, step_limit).await;
+            let outcome =
+                run_pipeline(source, target, work_state, cancel, step_limit, last_created_at)
+                    .await;
             let _ = state_tx.send(outcome);
         });
 
@@ -651,6 +680,7 @@ async fn run_pipeline(
     work_state: Arc<StdMutex<PipelineWorkState>>,
     cancel: CancellationToken,
     step_limit: Option<usize>,
+    last_created_at_us: Arc<HashMap<String, AtomicI64>>,
 ) -> PipelineState {
     // Take a snapshot of total counts for logging.
     let (total_steps, total_batches) = {
@@ -762,6 +792,7 @@ async fn run_pipeline(
         for table_name in active_tables {
             let data_storage = Arc::clone(&data_storage);
             let data_sink = Arc::clone(&data_sink);
+            let last_created_at = Arc::clone(&last_created_at_us);
 
             join_set.spawn(async move {
                 // 1. Read from source
@@ -806,7 +837,10 @@ async fn run_pipeline(
                     };
 
                     for segment in segments {
-                        let rehydrated = match append_created_at(&segment.batch) {
+                        let tracker = last_created_at
+                            .get(&table_name)
+                            .expect("table missing from last_created_at map");
+                        let rehydrated = match append_created_at(&segment.batch, tracker) {
                             Ok(b) => b,
                             Err(e) => {
                                 error!(

--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -20,6 +20,7 @@ use arrow::array::{Array, TimestampMicrosecondArray};
 use etl::{ETLPipeline, PipelineState, StopReason};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 use system_adapter_protocol::MetricsResponse;
 use test_framework::{
@@ -129,6 +130,7 @@ fn spawn_e2e_latency_check(
     table_names: Vec<String>,
     token: CancellationToken,
     interval: Duration,
+    last_created_at_us: Arc<HashMap<String, AtomicI64>>,
 ) -> tokio::task::JoinHandle<HashMap<String, Vec<f64>>> {
     tokio::spawn(async move {
         let mut samples_by_table: HashMap<String, Vec<f64>> = table_names
@@ -144,11 +146,8 @@ fn spawn_e2e_latency_check(
 
             let conn = Arc::clone(&conn);
             let tables = table_names.clone();
+            let timestamps = Arc::clone(&last_created_at_us);
             let results = tokio::task::spawn_blocking(move || {
-                let now_us = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_micros() as i64;
                 let mut out: Vec<(String, Option<f64>)> = Vec::new();
                 let mut guard = match conn.lock() {
                     Ok(g) => g,
@@ -158,6 +157,13 @@ fn spawn_e2e_latency_check(
                     }
                 };
                 for table in &tables {
+                    let last_written_us = timestamps
+                        .get(table.as_str())
+                        .map_or(0, |a| a.load(Ordering::Relaxed));
+                    if last_written_us == 0 {
+                        out.push((table.clone(), None));
+                        continue;
+                    }
                     let sql = format!("SELECT MAX(__created_at) FROM {table}");
                     match guard.query(&sql) {
                         Ok(batches) => {
@@ -169,7 +175,7 @@ fn spawn_e2e_latency_check(
                                     return None;
                                 }
                                 let max_ts_us = ts_array.value(0);
-                                Some((now_us - max_ts_us) as f64 / 1000.0)
+                                Some((last_written_us - max_ts_us) as f64 / 1000.0)
                             });
                             out.push((table.clone(), sample));
                         }
@@ -264,6 +270,7 @@ pub(crate) async fn run(
         table_names,
         e2e_latency_token.clone(),
         Duration::from_secs(5),
+        etl_pipeline.last_created_at_us(),
     );
 
     // Record client concurrency as a gauge


### PR DESCRIPTION
## 🗣 Description

Update e2e latency metric: for each table use current `created_at` instead of `now()`