### PR TITLE
fix: Correctly create checkpoints when there are no rows

### DIFF
--- a/crates/checkpointer/src/main.rs
+++ b/crates/checkpointer/src/main.rs
@@ -123,7 +123,6 @@ async fn run_checkpoint_queries(
         tracing::info!(
             checkpoint = checkpoint_idx,
             query = query_idx,
-            sql = %sql,
             "Running checkpoint query"
         );
 
@@ -131,24 +130,12 @@ async fn run_checkpoint_queries(
         let out_path = resolved_checkpoint_dir.join(format!("{query_idx}.parquet"));
 
         // Derive the result schema. If the query returned rows, use the first
-        // batch's schema. Otherwise, run a LIMIT 0 wrapper to obtain it.
+        // batch's schema. Otherwise, ask DuckDB for the schema directly — this
+        // works even when zero rows are returned.
         let result_schema = if let Some(first) = batches.first() {
             first.schema()
         } else {
-            let trimmed = sql.trim_end().trim_end_matches(';');
-            let schema_sql = format!("SELECT * FROM ({trimmed}) AS __q LIMIT 0");
-            let schema_batches = sink.query(&schema_sql).await?;
-            match schema_batches.first() {
-                Some(b) => b.schema(),
-                None => {
-                    tracing::warn!(
-                        checkpoint = checkpoint_idx,
-                        query = query_idx,
-                        "Query returned no rows and schema could not be determined, skipping"
-                    );
-                    continue;
-                }
-            }
+            sink.query_schema(sql).await?
         };
 
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();

--- a/crates/etl/src/sink/duckdb.rs
+++ b/crates/etl/src/sink/duckdb.rs
@@ -298,6 +298,45 @@ impl DuckDBSink {
         })
         .await?
     }
+
+    /// Returns the result schema of an arbitrary SQL query without requiring
+    /// any rows to be returned. This uses DuckDB's `query_arrow` +
+    /// `get_schema()` which provides the schema even for empty result sets.
+    pub async fn query_schema(&self, sql: &str) -> anyhow::Result<arrow::datatypes::SchemaRef> {
+        let conn = Arc::clone(&self.conn);
+        let sql = sql.to_string();
+        tokio::task::spawn_blocking(move || {
+            let guard = conn
+                .lock()
+                .map_err(|e| anyhow::anyhow!("DuckDB connection lock poisoned: {e}"))?;
+            let mut stmt = guard
+                .prepare(&sql)
+                .map_err(|e| anyhow::anyhow!("Failed to prepare DuckDB query: {e}"))?;
+            let result = stmt
+                .query_arrow([])
+                .map_err(|e| anyhow::anyhow!("Failed to execute DuckDB query: {e}"))?;
+            let duckdb_schema = result.get_schema();
+
+            // Convert from duckdb::arrow::Schema to arrow::datatypes::Schema
+            // via IPC serialization round-trip for crate compatibility.
+            let mut buf = Vec::new();
+            {
+                let mut writer = duckdb::arrow::ipc::writer::FileWriter::try_new(
+                    &mut buf,
+                    &duckdb_schema,
+                )
+                .map_err(|e| anyhow::anyhow!("IPC write init failed: {e}"))?;
+                writer
+                    .finish()
+                    .map_err(|e| anyhow::anyhow!("IPC finish failed: {e}"))?;
+            }
+            let reader =
+                arrow::ipc::reader::FileReader::try_new(std::io::Cursor::new(buf), None)
+                    .map_err(|e| anyhow::anyhow!("IPC read failed: {e}"))?;
+            Ok(reader.schema())
+        })
+        .await?
+    }
 }
 
 #[async_trait]

--- a/crates/etl/src/sink/duckdb.rs
+++ b/crates/etl/src/sink/duckdb.rs
@@ -321,18 +321,15 @@ impl DuckDBSink {
             // via IPC serialization round-trip for crate compatibility.
             let mut buf = Vec::new();
             {
-                let mut writer = duckdb::arrow::ipc::writer::FileWriter::try_new(
-                    &mut buf,
-                    &duckdb_schema,
-                )
-                .map_err(|e| anyhow::anyhow!("IPC write init failed: {e}"))?;
+                let mut writer =
+                    duckdb::arrow::ipc::writer::FileWriter::try_new(&mut buf, &duckdb_schema)
+                        .map_err(|e| anyhow::anyhow!("IPC write init failed: {e}"))?;
                 writer
                     .finish()
                     .map_err(|e| anyhow::anyhow!("IPC finish failed: {e}"))?;
             }
-            let reader =
-                arrow::ipc::reader::FileReader::try_new(std::io::Cursor::new(buf), None)
-                    .map_err(|e| anyhow::anyhow!("IPC read failed: {e}"))?;
+            let reader = arrow::ipc::reader::FileReader::try_new(std::io::Cursor::new(buf), None)
+                .map_err(|e| anyhow::anyhow!("IPC read failed: {e}"))?;
             Ok(reader.schema())
         })
         .await?


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Retrieve the schema from duckdb correctly when a query has no rows for checkpointing