### PR TITLE
refactor: Update the format of data generation and manifests

### DIFF
--- a/.github/workflows/data_generation_run.yml
+++ b/.github/workflows/data_generation_run.yml
@@ -1,5 +1,5 @@
 name: data-generation run
-run-name: data-generation run - ${{ github.event.inputs.scenario }} - sf${{ github.event.inputs.scale_factor }}
+run-name: data-generation run - ${{ github.event.inputs.scenario }} - v${{ github.event.inputs.version }} - sf${{ github.event.inputs.scale_factor }}
 
 on:
   workflow_call:
@@ -7,6 +7,9 @@ on:
       scenario:
         required: false
         default: 'tpch'
+        type: string
+      version:
+        required: true
         type: string
       scale_factor:
         required: false
@@ -51,6 +54,10 @@ on:
         description: 'GitHub runner label to execute on'
         required: false
         default: 'spiceai-macos'
+        type: string
+      version:
+        description: 'Version identifier for this generation (e.g. 1, 2, 3)'
+        required: true
         type: string
       scale_factor:
         description: 'TPC-H scale factor'
@@ -116,9 +123,10 @@ jobs:
       - name: Run data generation
         env:
           SCENARIO: ${{ inputs.scenario || github.event.inputs.scenario || 'tpch' }}
+          VERSION: ${{ inputs.version || github.event.inputs.version }}
           SCALE_FACTOR: ${{ inputs.scale_factor || github.event.inputs.scale_factor || '1.0' }}
           BUCKET: ${{ inputs.bucket || github.event.inputs.bucket }}
-          PREFIX_BASE: ${{ inputs.prefix || github.event.inputs.prefix || 'data-gen' }}
+          PREFIX: ${{ inputs.prefix || github.event.inputs.prefix || 'data-gen' }}
           MAX_CONCURRENCY: ${{ inputs.max_concurrency || github.event.inputs.max_concurrency || '8' }}
           REGION: ${{ inputs.region || github.event.inputs.region || 'us-east-1' }}
           SKIP_INITIAL: ${{ inputs.skip_initial || github.event.inputs.skip_initial || false }}
@@ -126,10 +134,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           RUST_LOG: info
         run: |
-          PREFIX="${PREFIX_BASE}"
-          PREFIX="${PREFIX%/}/${SCENARIO}"
-
           ARGS="--dataset ${SCENARIO}"
+          ARGS="${ARGS} --scenario ${SCENARIO}"
+          ARGS="${ARGS} --version ${VERSION}"
           ARGS="${ARGS} --scale-factor ${SCALE_FACTOR}"
           ARGS="${ARGS} --bucket ${BUCKET}"
           ARGS="${ARGS} --prefix ${PREFIX}"
@@ -162,24 +169,18 @@ jobs:
       - name: Run checkpointer
         env:
           SCENARIO: ${{ inputs.scenario || github.event.inputs.scenario || 'tpch' }}
-          SCALE_FACTOR: ${{ inputs.scale_factor || github.event.inputs.scale_factor || '1.0' }}
+          VERSION: ${{ inputs.version || github.event.inputs.version }}
           BUCKET: ${{ inputs.bucket || github.event.inputs.bucket }}
-          PREFIX_BASE: ${{ inputs.prefix || github.event.inputs.prefix || 'data-gen' }}
+          PREFIX: ${{ inputs.prefix || github.event.inputs.prefix || 'data-gen' }}
           REGION: ${{ inputs.region || github.event.inputs.region || 'us-east-1' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           RUST_LOG: info
         run: |
-          PREFIX="${PREFIX_BASE}"
-          PREFIX="${PREFIX%/}/${SCENARIO}"
-
-          SOURCE_PREFIX="${PREFIX}/${SCALE_FACTOR}"
-
           ARGS="--scenario ${SCENARIO}"
-          ARGS="${ARGS} --dataset ${SCENARIO}"
-          ARGS="${ARGS} --scale-factor ${SCALE_FACTOR}"
+          ARGS="${ARGS} --version ${VERSION}"
           ARGS="${ARGS} --bucket ${BUCKET}"
-          ARGS="${ARGS} --source-prefix ${SOURCE_PREFIX}"
+          ARGS="${ARGS} --prefix ${PREFIX}"
           ARGS="${ARGS} --duckdb-path ./checkpointer.duckdb"
           ARGS="${ARGS} --checkpoint-dir ./checkpoints"
 

--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -30,10 +30,14 @@ on:
         required: true
         default: 'spiceai-public-datasets'
         type: string
-      etl_source_prefix:
-        description: 'S3 key prefix for ETL source data'
+      etl_prefix:
+        description: 'S3 key prefix (the {prefix} portion of {prefix}/{scenario}/{version}/)'
         required: false
-        default: 'data-gen/tpch/1.0'
+        default: 'data-gen'
+        type: string
+      etl_version:
+        description: 'Version identifier for the data generation to read from'
+        required: true
         type: string
       etl_region:
         description: 'AWS region for the ETL S3 bucket'
@@ -43,11 +47,6 @@ on:
       etl_endpoint:
         description: 'S3 endpoint URL for ETL bucket (for MinIO/LocalStack)'
         required: false
-        type: string
-      etl_num_steps:
-        description: 'Number of ETL data generation steps (partitions)'
-        required: false
-        default: '25'
         type: string
       table_format:
         description: 'Table format across generation and adapter setup (iceberg, parquet, delta)'
@@ -226,19 +225,19 @@ jobs:
           SYSTEM_ADAPTER: ${{ github.event.inputs.system_adapter || 'spidapter' }}
           EXECUTOR_INSTANCE_TYPE: ${{ github.event.inputs.executor_instance_type || 'github-hosted-ubuntu-latest' }}
           ETL_BUCKET: ${{ github.event.inputs.etl_bucket }}
-          ETL_SOURCE_PREFIX: ${{ github.event.inputs.etl_source_prefix }}
+          ETL_PREFIX: ${{ github.event.inputs.etl_prefix || 'data-gen' }}
+          ETL_VERSION: ${{ github.event.inputs.etl_version }}
           ETL_REGION: ${{ github.event.inputs.etl_region || 'us-east-1' }}
           ETL_ENDPOINT: ${{ github.event.inputs.etl_endpoint }}
-          ETL_NUM_STEPS: ${{ github.event.inputs.etl_num_steps || '25' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SPIDAPTER_ICEBERG_REGION: us-west-1
           SPIDAPTER_ICEBERG_CATALOG_FROM: iceberg:https://glue.us-west-1.amazonaws.com/iceberg/v1/catalogs/211125479522/namespaces
           RUST_LOG: 'info'
         run: |
-          ETL_ARGS="--etl-bucket ${ETL_BUCKET} --etl-num-steps ${ETL_NUM_STEPS}"
-          if [ -n "${ETL_SOURCE_PREFIX}" ]; then
-            ETL_ARGS="${ETL_ARGS} --etl-source-prefix ${ETL_SOURCE_PREFIX}"
+          ETL_ARGS="--etl-bucket ${ETL_BUCKET} --etl-version ${ETL_VERSION}"
+          if [ -n "${ETL_PREFIX}" ]; then
+            ETL_ARGS="${ETL_ARGS} --etl-prefix ${ETL_PREFIX}"
           fi
           if [ -n "${ETL_REGION}" ]; then
             ETL_ARGS="${ETL_ARGS} --etl-region ${ETL_REGION}"

--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -39,6 +39,7 @@ on:
         description: 'Version identifier for the data generation to read from'
         required: true
         type: string
+        default: "1"
       etl_region:
         description: 'AWS region for the ETL S3 bucket'
         required: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "object_store",
  "parquet",
  "rand 0.9.2",
+ "serde",
  "serde_json",
  "tokio",
  "tpchgen",

--- a/crates/checkpointer/src/lib.rs
+++ b/crates/checkpointer/src/lib.rs
@@ -18,14 +18,16 @@ limitations under the License.
 //!
 //! ## Layout
 //!
+//! Checkpoints are stored under the version directory:
+//!
 //! ```text
-//! s3://{bucket}/{prefix}/checkpoints/{checkpoint_idx}/{query_idx}.parquet
-//! s3://{bucket}/{prefix}/checkpoints.json          ← manifest
+//! s3://{bucket}/{prefix}/{scenario}/{version}/checkpoints/{checkpoint_idx}/{query_idx}.parquet
+//! s3://{bucket}/{prefix}/{scenario}/{version}/checkpoints.json          ← manifest
 //! ```
 //!
-//! The manifest (`checkpoints.json`) contains metadata for every scenario
-//! that has been checkpointed under the given prefix. The prefix is expected
-//! to already scope to the scenario and scale factor (e.g. `data-gen/tpch/1.0`).
+//! The `prefix` passed to [`CheckpointStore`] is the fully-qualified version
+//! prefix (`{prefix}/{scenario}/{version}`), so checkpoint paths are relative
+//! to that.
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/checkpointer/src/main.rs
+++ b/crates/checkpointer/src/main.rs
@@ -110,11 +110,8 @@ impl Cli {
     /// Builds the source config with the versioned prefix:
     /// `{prefix}/{scenario}/{version}`
     fn source_config(&self) -> TargetConfig {
-        let version_prefix = build_version_prefix(
-            &self.prefix,
-            &self.scenario.to_string(),
-            self.version,
-        );
+        let version_prefix =
+            build_version_prefix(&self.prefix, &self.scenario.to_string(), self.version);
         TargetConfig {
             bucket: self.bucket.clone(),
             prefix: version_prefix,

--- a/crates/checkpointer/src/main.rs
+++ b/crates/checkpointer/src/main.rs
@@ -176,12 +176,11 @@ async fn main() -> anyhow::Result<()> {
     let source = Arc::new(S3Storage::new(&source_config)?);
 
     // Read version metadata to derive dataset config and mutations.
-    let version_metadata = source
-        .read_version_metadata()
-        .await?
-        .ok_or_else(|| anyhow::anyhow!(
+    let version_metadata = source.read_version_metadata().await?.ok_or_else(|| {
+        anyhow::anyhow!(
             "No version.json found at {version_prefix}. Was data generation run for this version?"
-        ))?;
+        )
+    })?;
 
     let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
     let dataset_config = version_metadata.dataset_config();

--- a/crates/checkpointer/src/main.rs
+++ b/crates/checkpointer/src/main.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use checkpointer::CheckpointStore;
 use clap::Parser;
-use data_generation::config::{DatasetConfig, TargetConfig};
+use data_generation::config::{DatasetConfig, TargetConfig, build_version_prefix};
 use data_generation::dataset::MutationConfig;
 use data_generation::storage::s3::S3Storage;
 use etl::sink::duckdb::DuckDBSink;
@@ -39,6 +39,10 @@ struct Cli {
     #[arg(long, value_enum, default_value = "tpch")]
     scenario: Scenario,
 
+    /// Version identifier for the data generation to read from.
+    #[arg(long)]
+    version: u64,
+
     /// Dataset type: "tpch" or "simple_sequence"
     #[arg(long, default_value = "tpch")]
     dataset: String,
@@ -55,9 +59,10 @@ struct Cli {
     #[arg(long)]
     bucket: String,
 
-    /// S3 key prefix for source data
+    /// S3 key prefix (the `{prefix}` portion of `{prefix}/{scenario}/{version}/`)
     #[arg(long, default_value = "")]
-    source_prefix: String,
+    prefix: String,
+
     /// AWS region
     #[arg(long)]
     region: Option<String>,
@@ -102,10 +107,17 @@ impl Cli {
         }
     }
 
+    /// Builds the source config with the versioned prefix:
+    /// `{prefix}/{scenario}/{version}`
     fn source_config(&self) -> TargetConfig {
+        let version_prefix = build_version_prefix(
+            &self.prefix,
+            &self.scenario.to_string(),
+            self.version,
+        );
         TargetConfig {
             bucket: self.bucket.clone(),
-            prefix: self.source_prefix.clone(),
+            prefix: version_prefix,
             region: self.region.clone(),
             endpoint: self.endpoint.clone(),
         }
@@ -195,7 +207,9 @@ async fn main() -> anyhow::Result<()> {
     let dataset_source = cli.dataset_source()?;
     let dataset_config = cli.dataset_config();
 
-    let source = Arc::new(S3Storage::new(&cli.source_config())?);
+    let source_config = cli.source_config();
+    let version_prefix = source_config.prefix.clone();
+    let source = Arc::new(S3Storage::new(&source_config)?);
 
     let target = Arc::new(DuckDBSink::new(&cli.duckdb_path)?);
     let target_sink: Arc<dyn etl::sink::Sink> = Arc::clone(&target) as Arc<dyn etl::sink::Sink>;
@@ -213,9 +227,11 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!(
         scenario = %scenario_name,
+        version = cli.version,
         dataset = %cli.dataset,
         bucket = %cli.bucket,
-        source_prefix = %cli.source_prefix,
+        prefix = %cli.prefix,
+        version_prefix = %version_prefix,
         duckdb_path = %cli.duckdb_path.display(),
         scale_factor = cli.scale_factor,
         num_steps = cli.num_steps,
@@ -271,10 +287,10 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .await?;
 
-                // Upload all checkpoints to S3.
+                // Upload all checkpoints to S3 under the version prefix.
                 let checkpoint_store = CheckpointStore::new(
                     &cli.bucket,
-                    &cli.source_prefix,
+                    &version_prefix,
                     cli.region.as_deref(),
                     cli.endpoint.as_deref(),
                 )?;

--- a/crates/checkpointer/src/main.rs
+++ b/crates/checkpointer/src/main.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use arrow::array::RecordBatch;
 use checkpointer::CheckpointStore;
 use clap::Parser;
-use data_generation::config::{DatasetConfig, TargetConfig, build_version_prefix};
-use data_generation::dataset::MutationConfig;
+use data_generation::config::{TargetConfig, build_version_prefix};
+use data_generation::storage::DataStorage;
 use data_generation::storage::s3::S3Storage;
 use etl::sink::duckdb::DuckDBSink;
 use etl::{DatasetSource, ETLPipeline, PipelineState, StopReason};
@@ -42,18 +42,6 @@ struct Cli {
     /// Version identifier for the data generation to read from.
     #[arg(long)]
     version: u64,
-
-    /// Dataset type: "tpch" or "simple_sequence"
-    #[arg(long, default_value = "tpch")]
-    dataset: String,
-
-    /// Scale factor for data generation
-    #[arg(long, default_value_t = 1.0)]
-    scale_factor: f64,
-
-    /// Number of data generation steps (partitions)
-    #[arg(long, default_value_t = 25)]
-    num_steps: u16,
 
     /// S3 bucket name (used for both source and target)
     #[arg(long)]
@@ -89,24 +77,6 @@ struct Cli {
 }
 
 impl Cli {
-    fn dataset_source(&self) -> anyhow::Result<DatasetSource> {
-        match self.dataset.as_str() {
-            "tpch" => Ok(DatasetSource::Tpch),
-            "simple_sequence" => Ok(DatasetSource::SimpleSequence),
-            other => {
-                anyhow::bail!("Unknown dataset type: {other}. Use 'tpch' or 'simple_sequence'.")
-            }
-        }
-    }
-
-    fn dataset_config(&self) -> DatasetConfig {
-        DatasetConfig {
-            dataset_type: self.dataset.clone(),
-            scale_factor: self.scale_factor,
-            num_steps: self.num_steps,
-        }
-    }
-
     /// Builds the source config with the versioned prefix:
     /// `{prefix}/{scenario}/{version}`
     fn source_config(&self) -> TargetConfig {
@@ -201,17 +171,24 @@ async fn main() -> anyhow::Result<()> {
         .map(|q| q.sql.to_string())
         .collect();
 
-    let dataset_source = cli.dataset_source()?;
-    let dataset_config = cli.dataset_config();
-
     let source_config = cli.source_config();
     let version_prefix = source_config.prefix.clone();
     let source = Arc::new(S3Storage::new(&source_config)?);
 
+    // Read version metadata to derive dataset config and mutations.
+    let version_metadata = source
+        .read_version_metadata()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!(
+            "No version.json found at {version_prefix}. Was data generation run for this version?"
+        ))?;
+
+    let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
+    let dataset_config = version_metadata.dataset_config();
+    let mutations = version_metadata.mutation_config();
+
     let target = Arc::new(DuckDBSink::new(&cli.duckdb_path)?);
     let target_sink: Arc<dyn etl::sink::Sink> = Arc::clone(&target) as Arc<dyn etl::sink::Sink>;
-
-    let mutations = MutationConfig::new(0.0, 0.0);
 
     let mut pipeline = ETLPipeline::new(
         dataset_source,
@@ -225,13 +202,13 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!(
         scenario = %scenario_name,
         version = cli.version,
-        dataset = %cli.dataset,
+        dataset = %version_metadata.dataset_type,
         bucket = %cli.bucket,
         prefix = %cli.prefix,
         version_prefix = %version_prefix,
         duckdb_path = %cli.duckdb_path.display(),
-        scale_factor = cli.scale_factor,
-        num_steps = cli.num_steps,
+        scale_factor = version_metadata.scale_factor,
+        num_steps = version_metadata.num_steps,
         checkpoint_interval = cli.checkpoint_interval_steps,
         checkpoint_dir = %cli.checkpoint_dir.display(),
         "Starting Checkpointer"

--- a/crates/data-generation/Cargo.toml
+++ b/crates/data-generation/Cargo.toml
@@ -27,6 +27,7 @@ tpchgen.workspace = true
 tpchgen-arrow.workspace = true
 parquet.workspace = true
 rand.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/data-generation/src/config.rs
+++ b/crates/data-generation/src/config.rs
@@ -59,9 +59,18 @@ pub struct CommonArgs {
     #[arg(long)]
     pub bucket: String,
 
-    /// S3 key prefix for generated files
+    /// S3 key prefix for generated files (the `{prefix}` portion of the path)
     #[arg(long, default_value = "")]
     pub prefix: String,
+
+    /// Scenario name (e.g. "tpch") — used as `{scenario}` in the storage path `{prefix}/{scenario}/{version}/`
+    #[arg(long, default_value = "tpch")]
+    pub scenario: String,
+
+    /// Version identifier for this generation (e.g. 1, 2, 3).
+    /// Storage path: `{prefix}/{scenario}/{version}/`
+    #[arg(long)]
+    pub version: u64,
 
     /// AWS region
     #[arg(long)]
@@ -84,6 +93,7 @@ pub struct DatasetConfig {
 
 pub struct TargetConfig {
     pub bucket: String,
+    /// The fully-qualified prefix: `{prefix}/{scenario}/{version}`
     pub prefix: String,
     pub region: Option<String>,
     pub endpoint: Option<String>,
@@ -102,10 +112,14 @@ impl CommonArgs {
         }
     }
 
+    /// Builds the target config with the version-based storage path.
+    ///
+    /// The resulting prefix is `{prefix}/{scenario}/{version}`.
     pub fn target_config(&self) -> TargetConfig {
+        let prefix = build_version_prefix(&self.prefix, &self.scenario, self.version);
         TargetConfig {
             bucket: self.bucket.clone(),
-            prefix: format!("{}/{}", self.prefix, format_scale_factor(self.scale_factor)),
+            prefix,
             region: self.region.clone(),
             endpoint: self.endpoint.clone(),
         }
@@ -115,6 +129,17 @@ impl CommonArgs {
         IngestorConfig {
             max_concurrency: self.max_concurrency,
         }
+    }
+}
+
+/// Builds the versioned storage prefix: `{prefix}/{scenario}/{version}`.
+///
+/// If `prefix` is empty, the result is `{scenario}/{version}`.
+pub fn build_version_prefix(prefix: &str, scenario: &str, version: u64) -> String {
+    if prefix.is_empty() {
+        format!("{scenario}/{version}")
+    } else {
+        format!("{prefix}/{scenario}/{version}")
     }
 }
 

--- a/crates/data-generation/src/dataset/mod.rs
+++ b/crates/data-generation/src/dataset/mod.rs
@@ -140,8 +140,8 @@ impl DatasetTable {
 
 #[derive(Debug, Clone)]
 pub struct MutationConfig {
-    pub(crate) update_ratio: f64,
-    pub(crate) delete_ratio: f64,
+    pub update_ratio: f64,
+    pub delete_ratio: f64,
 }
 
 impl MutationConfig {

--- a/crates/data-generation/src/generator.rs
+++ b/crates/data-generation/src/generator.rs
@@ -25,12 +25,28 @@ use super::config::IngestorConfig;
 use super::dataset::Dataset;
 use super::metrics::{IngestResult, Metrics};
 use super::storage::DataStorage;
+use super::version::{
+    MutationsMetadata, TableMetadata, VersionMetadata, arrow_schema_to_json,
+};
+
+/// Configuration for the version metadata that will be written at the end
+/// of a data generation run.
+pub struct VersionConfig {
+    pub version: u64,
+    pub scenario: String,
+    pub scale_factor: f64,
+    pub num_steps: u16,
+    pub dataset_type: String,
+    pub update_ratio: f64,
+    pub delete_ratio: f64,
+}
 
 pub struct DataGenerator {
     dataset: Arc<dyn Dataset>,
     target: Arc<dyn DataStorage>,
     metrics: Metrics,
     semaphore: Arc<Semaphore>,
+    version_config: VersionConfig,
 }
 
 impl DataGenerator {
@@ -39,12 +55,14 @@ impl DataGenerator {
         target: Arc<dyn DataStorage>,
         config: &IngestorConfig,
         metrics: Metrics,
+        version_config: VersionConfig,
     ) -> Self {
         Self {
             dataset,
             target,
             metrics,
             semaphore: Arc::new(Semaphore::new(config.max_concurrency)),
+            version_config,
         }
     }
 
@@ -205,23 +223,58 @@ impl DataGenerator {
 
         logger_handle.abort();
 
-        // Persist table-level metadata (key columns + batch IDs) for each table.
+        // Build and persist the consolidated version metadata (version.json).
         let written = Arc::try_unwrap(written_batch_ids)
             .expect("all tasks should be finished")
             .into_inner()
             .expect("mutex should not be poisoned");
+
+        let dataset_tables = self.dataset.tables();
+        let mut tables_metadata = HashMap::new();
         for (table_name, mut ids) in written {
             ids.sort_unstable();
             let key_columns = self.dataset.primary_key(&table_name);
-            self.target
-                .write_table_metadata(&table_name, &key_columns, &ids)
-                .await?;
+            let dataset_table = dataset_tables.get(&table_name);
+            let schema_json = dataset_table
+                .map(|t| arrow_schema_to_json(&t.rehydrated_schema()))
+                .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+            let time_column = dataset_table
+                .map(|t| t.time_column.clone())
+                .unwrap_or_default();
+
+            tables_metadata.insert(
+                table_name.clone(),
+                TableMetadata {
+                    name: table_name.clone(),
+                    schema: schema_json,
+                    time_column,
+                    key_columns,
+                    batch_ids: ids.clone(),
+                },
+            );
+
             tracing::info!(
                 table = %table_name,
                 batch_count = ids.len(),
-                "Table metadata written"
+                "Table metadata collected"
             );
         }
+
+        let version_metadata = VersionMetadata {
+            version: self.version_config.version,
+            scenario: self.version_config.scenario.clone(),
+            scale_factor: self.version_config.scale_factor,
+            num_steps: self.version_config.num_steps,
+            dataset_type: self.version_config.dataset_type.clone(),
+            mutations: MutationsMetadata {
+                update_ratio: self.version_config.update_ratio,
+                delete_ratio: self.version_config.delete_ratio,
+            },
+            tables: tables_metadata,
+        };
+
+        self.target.write_version_metadata(&version_metadata).await?;
+        tracing::info!("version.json written");
 
         let summary = self.metrics.summary();
         tracing::info!(

--- a/crates/data-generation/src/generator.rs
+++ b/crates/data-generation/src/generator.rs
@@ -25,9 +25,7 @@ use super::config::IngestorConfig;
 use super::dataset::Dataset;
 use super::metrics::{IngestResult, Metrics};
 use super::storage::DataStorage;
-use super::version::{
-    MutationsMetadata, TableMetadata, VersionMetadata, arrow_schema_to_json,
-};
+use super::version::{MutationsMetadata, TableMetadata, VersionMetadata, arrow_schema_to_json};
 
 /// Configuration for the version metadata that will be written at the end
 /// of a data generation run.
@@ -273,7 +271,9 @@ impl DataGenerator {
             tables: tables_metadata,
         };
 
-        self.target.write_version_metadata(&version_metadata).await?;
+        self.target
+            .write_version_metadata(&version_metadata)
+            .await?;
         tracing::info!("version.json written");
 
         let summary = self.metrics.summary();

--- a/crates/data-generation/src/lib.rs
+++ b/crates/data-generation/src/lib.rs
@@ -19,3 +19,4 @@ pub mod dataset;
 pub mod generator;
 pub mod metrics;
 pub mod storage;
+pub mod version;

--- a/crates/data-generation/src/main.rs
+++ b/crates/data-generation/src/main.rs
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 use clap::Parser;
-use data_generation::generator::DataGenerator;
+use data_generation::generator::{DataGenerator, VersionConfig};
 use data_generation::storage::DataStorage;
 use tracing_subscriber::EnvFilter;
 
@@ -60,6 +60,8 @@ fn build(args: &CommonArgs) -> anyhow::Result<DataGenerator> {
         max_concurrency = ingestor_config.max_concurrency,
         bucket = target_config.bucket,
         prefix = target_config.prefix,
+        version = args.version,
+        scenario = %args.scenario,
         "Configuration"
     );
 
@@ -72,11 +74,22 @@ fn build(args: &CommonArgs) -> anyhow::Result<DataGenerator> {
 
     let metrics = Metrics::new();
 
+    let version_config = VersionConfig {
+        version: args.version,
+        scenario: args.scenario.clone(),
+        scale_factor: args.scale_factor,
+        num_steps: args.num_steps,
+        dataset_type: args.dataset.clone(),
+        update_ratio: mutations_config.update_ratio,
+        delete_ratio: mutations_config.delete_ratio,
+    };
+
     let ingestor = DataGenerator::new(
         dataset,
         target as Arc<dyn DataStorage>,
         &ingestor_config,
         metrics,
+        version_config,
     );
     Ok(ingestor)
 }

--- a/crates/data-generation/src/storage/mod.rs
+++ b/crates/data-generation/src/storage/mod.rs
@@ -68,10 +68,7 @@ pub trait DataStorage: Send + Sync + 'static {
     /// Writes the consolidated version metadata (`version.json`) for this
     /// generation version. Contains scale factor, mutations config, and
     /// per-table metadata (schemas, key columns, batch IDs).
-    async fn write_version_metadata(
-        &self,
-        _metadata: &VersionMetadata,
-    ) -> anyhow::Result<()> {
+    async fn write_version_metadata(&self, _metadata: &VersionMetadata) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/crates/data-generation/src/storage/mod.rs
+++ b/crates/data-generation/src/storage/mod.rs
@@ -21,6 +21,8 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
+use crate::version::VersionMetadata;
+
 pub struct ReadResult {
     pub batches: Vec<RecordBatch>,
     pub rows_read: u64,
@@ -36,6 +38,8 @@ pub struct WriteResult {
 #[async_trait]
 pub trait DataStorage: Send + Sync + 'static {
     /// List available batch object paths for a given table.
+    ///
+    /// Batches are stored under `tables/{table_name}/batch-NNNNNN.parquet`.
     async fn list_batches(&self, table_name: &str) -> anyhow::Result<Vec<String>>;
 
     /// Read a single batch from the source by its batch ID and table name.
@@ -44,14 +48,16 @@ pub trait DataStorage: Send + Sync + 'static {
     /// storage (e.g. the table has fewer batches than others). The caller
     /// should treat this as the table having no more data.
     ///
-    /// The concrete implementation is responsible for mapping `(table_name,
-    /// batch_id)` to the underlying storage path.
+    /// Batches are stored at `tables/{table_name}/batch-{batch_id:06}.parquet`.
     async fn read_batch(
         &self,
         table_name: &str,
         batch_id: u64,
     ) -> anyhow::Result<Option<ReadResult>>;
 
+    /// Write a single batch to storage for the given table and batch ID.
+    ///
+    /// Batches are written to `tables/{table_name}/batch-{batch_id:06}.parquet`.
     async fn write(
         &self,
         table_name: &str,
@@ -59,25 +65,49 @@ pub trait DataStorage: Send + Sync + 'static {
         batch: RecordBatch,
     ) -> anyhow::Result<WriteResult>;
 
-    /// Writes table-level metadata, including the key columns used for
-    /// update/delete operations and the batch IDs that were written.
-    ///
-    /// The default implementation is a no-op.  Backends that persist
-    /// metadata (e.g. S3) override this to write `metadata.json`.
-    async fn write_table_metadata(
+    /// Writes the consolidated version metadata (`version.json`) for this
+    /// generation version. Contains scale factor, mutations config, and
+    /// per-table metadata (schemas, key columns, batch IDs).
+    async fn write_version_metadata(
         &self,
-        _table_name: &str,
-        _key_columns: &[String],
-        _batch_ids: &[u64],
+        _metadata: &VersionMetadata,
     ) -> anyhow::Result<()> {
         Ok(())
     }
 
-    /// Reads the key columns from the table-level metadata.
+    /// Reads the version metadata (`version.json`) from storage.
     ///
-    /// Returns `Ok(Vec::new())` if no key columns are defined (pure inserts).
-    async fn read_key_columns(&self, _table_name: &str) -> anyhow::Result<Vec<String>> {
+    /// Returns `Ok(None)` if no version metadata exists.
+    async fn read_version_metadata(&self) -> anyhow::Result<Option<VersionMetadata>> {
+        Ok(None)
+    }
+
+    /// Returns key columns for a table by reading from the version metadata.
+    ///
+    /// Returns `Ok(Vec::new())` if no key columns are defined (pure inserts)
+    /// or if version metadata is not available.
+    async fn read_key_columns(&self, table_name: &str) -> anyhow::Result<Vec<String>> {
+        if let Some(metadata) = self.read_version_metadata().await? {
+            if let Some(table_meta) = metadata.tables.get(table_name) {
+                return Ok(table_meta.key_columns.clone());
+            }
+        }
         Ok(Vec::new())
+    }
+
+    /// Reads the batch IDs for a table from the version metadata.
+    ///
+    /// Returns the batch IDs in ascending order. If no version metadata exists
+    /// or the table is not found, returns an empty `VecDeque`.
+    async fn read_batch_ids(&self, table_name: &str) -> anyhow::Result<VecDeque<u64>> {
+        if let Some(metadata) = self.read_version_metadata().await? {
+            if let Some(table_meta) = metadata.tables.get(table_name) {
+                let mut ids = table_meta.batch_ids.clone();
+                ids.sort_unstable();
+                return Ok(VecDeque::from(ids));
+            }
+        }
+        Ok(VecDeque::new())
     }
 
     fn table_params(&self, table_name: &str) -> HashMap<String, serde_json::Value>;
@@ -88,13 +118,4 @@ pub trait DataStorage: Send + Sync + 'static {
     /// This is a planning method — no I/O is performed. Each implementation
     /// maps `(table_name, batch_id)` to its own path scheme (e.g. an S3 URI).
     fn expected_files(&self, table_name: &str, batch_ids: &[u64]) -> Vec<String>;
-
-    /// Reads the batch IDs recorded in the table-level metadata file.
-    ///
-    /// Returns the batch IDs in ascending order. If no metadata file exists
-    /// (or the implementation does not support metadata), the default
-    /// returns an empty `VecDeque`.
-    async fn read_batch_ids(&self, _table_name: &str) -> anyhow::Result<VecDeque<u64>> {
-        Ok(VecDeque::new())
-    }
 }

--- a/crates/data-generation/src/storage/s3.rs
+++ b/crates/data-generation/src/storage/s3.rs
@@ -100,9 +100,7 @@ impl S3Storage {
     /// Path: `{prefix}/tables/{table_name}/batch-{batch_id:06}.parquet`
     pub(crate) fn batch_object_path(&self, table_name: &str, batch_id: u64) -> ObjectPath {
         if self.prefix.is_empty() {
-            ObjectPath::from(format!(
-                "tables/{table_name}/batch-{batch_id:06}.parquet"
-            ))
+            ObjectPath::from(format!("tables/{table_name}/batch-{batch_id:06}.parquet"))
         } else {
             ObjectPath::from(format!(
                 "{}/tables/{table_name}/batch-{batch_id:06}.parquet",
@@ -208,10 +206,7 @@ impl DataStorage for S3Storage {
         })
     }
 
-    async fn write_version_metadata(
-        &self,
-        metadata: &VersionMetadata,
-    ) -> anyhow::Result<()> {
+    async fn write_version_metadata(&self, metadata: &VersionMetadata) -> anyhow::Result<()> {
         let path = self.version_metadata_object_path();
         let bytes = serde_json::to_vec_pretty(metadata)?;
         self.store.put(&path, PutPayload::from(bytes)).await?;

--- a/crates/data-generation/src/storage/s3.rs
+++ b/crates/data-generation/src/storage/s3.rs
@@ -22,6 +22,7 @@ use object_store::path::Path as ObjectPath;
 
 use crate::config::TargetConfig;
 use crate::storage::DataStorage;
+use crate::version::VersionMetadata;
 
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
@@ -32,18 +33,27 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 use std::collections::HashMap;
-use std::collections::VecDeque;
 
 use super::{ReadResult, WriteResult};
 
-/// Unified S3 storage backend that implements both [`Source`] and [`Target`].
+/// Unified S3 storage backend for versioned data generation.
 ///
-/// The trait implementations live in their respective modules
-/// (`source/s3.rs` and `target/s3.rs`) to keep concerns separated.
+/// Storage layout under the version prefix (`{prefix}/{scenario}/{version}/`):
+///
+/// ```text
+/// version.json
+/// tables/{table_name}/batch-000000.parquet
+/// tables/{table_name}/batch-000001.parquet
+/// checkpoints/
+///   checkpoints.json
+///   {checkpoint_idx}/{query_idx}.parquet
+/// ```
 #[derive(Clone)]
 pub struct S3Storage {
     pub(crate) store: Arc<dyn ObjectStore>,
     pub(crate) bucket: String,
+    /// The fully-qualified prefix including scenario and version:
+    /// `{prefix}/{scenario}/{version}`
     pub(crate) prefix: String,
     pub(crate) region: Option<String>,
 }
@@ -74,22 +84,28 @@ impl S3Storage {
         })
     }
 
-    /// Returns the S3 URI for a given table name (e.g. `s3://bucket/prefix/customer/`).
+    /// Returns the S3 URI for a given table's batch directory.
+    ///
+    /// e.g. `s3://bucket/{prefix}/tables/{table_name}/`
     pub fn table_s3_path(&self, table_name: &str) -> String {
         if self.prefix.is_empty() {
-            format!("s3://{}/{table_name}/", self.bucket)
+            format!("s3://{}/tables/{table_name}/", self.bucket)
         } else {
-            format!("s3://{}/{}/{table_name}/", self.bucket, self.prefix)
+            format!("s3://{}/{}/tables/{table_name}/", self.bucket, self.prefix)
         }
     }
 
     /// Returns the [`ObjectPath`] for a batch file within a table directory.
+    ///
+    /// Path: `{prefix}/tables/{table_name}/batch-{batch_id:06}.parquet`
     pub(crate) fn batch_object_path(&self, table_name: &str, batch_id: u64) -> ObjectPath {
         if self.prefix.is_empty() {
-            ObjectPath::from(format!("{table_name}/batch-{batch_id:06}.parquet"))
+            ObjectPath::from(format!(
+                "tables/{table_name}/batch-{batch_id:06}.parquet"
+            ))
         } else {
             ObjectPath::from(format!(
-                "{}/{table_name}/batch-{batch_id:06}.parquet",
+                "{}/tables/{table_name}/batch-{batch_id:06}.parquet",
                 self.prefix
             ))
         }
@@ -98,46 +114,19 @@ impl S3Storage {
     /// Returns the [`ObjectPath`] prefix for listing objects in a table directory.
     pub(crate) fn table_object_prefix(&self, table_name: &str) -> ObjectPath {
         if self.prefix.is_empty() {
-            ObjectPath::from(format!("{table_name}/"))
+            ObjectPath::from(format!("tables/{table_name}/"))
         } else {
-            ObjectPath::from(format!("{}/{table_name}/", self.prefix))
+            ObjectPath::from(format!("{}/tables/{table_name}/", self.prefix))
         }
     }
 
-    pub(crate) fn table_metadata_object_path(&self, table_name: &str) -> ObjectPath {
+    /// Returns the [`ObjectPath`] for the version metadata file.
+    pub(crate) fn version_metadata_object_path(&self) -> ObjectPath {
         if self.prefix.is_empty() {
-            ObjectPath::from(format!("{table_name}/metadata.json"))
+            ObjectPath::from("version.json")
         } else {
-            ObjectPath::from(format!("{}/{table_name}/metadata.json", self.prefix))
+            ObjectPath::from(format!("{}/version.json", self.prefix))
         }
-    }
-
-    /// Reads the key columns from the table-level metadata.
-    ///
-    /// Returns the `key_columns` array from `metadata.json`.
-    /// Returns an empty `Vec` if no metadata exists or key columns are not set.
-    async fn read_key_columns_from_metadata(
-        &self,
-        table_name: &str,
-    ) -> anyhow::Result<Vec<String>> {
-        let metadata_path = self.table_metadata_object_path(table_name);
-        let get_result = match self.store.get(&metadata_path).await {
-            Ok(r) => r,
-            Err(object_store::Error::NotFound { .. }) => return Ok(Vec::new()),
-            Err(e) => return Err(e.into()),
-        };
-
-        let bytes = get_result.bytes().await?;
-        let table_meta: serde_json::Value = serde_json::from_slice(&bytes)?;
-
-        let Some(keys) = table_meta.get("key_columns").and_then(|v| v.as_array()) else {
-            return Ok(Vec::new());
-        };
-
-        Ok(keys
-            .iter()
-            .filter_map(|v| v.as_str().map(ToOwned::to_owned))
-            .collect())
     }
 }
 
@@ -148,10 +137,13 @@ impl DataStorage for S3Storage {
             .iter()
             .map(|id| {
                 if self.prefix.is_empty() {
-                    format!("s3://{}/{table_name}/batch-{id:06}.parquet", self.bucket)
+                    format!(
+                        "s3://{}/tables/{table_name}/batch-{id:06}.parquet",
+                        self.bucket
+                    )
                 } else {
                     format!(
-                        "s3://{}/{}/{table_name}/batch-{id:06}.parquet",
+                        "s3://{}/{}/tables/{table_name}/batch-{id:06}.parquet",
                         self.bucket, self.prefix
                     )
                 }
@@ -205,7 +197,7 @@ impl DataStorage for S3Storage {
 
         let bytes_written = buf.len() as u64;
 
-        // Upload to S3 with per-table directory structure
+        // Upload to S3 under tables/{table_name}/
         let path = self.batch_object_path(table_name, batch_id);
 
         self.store.put(&path, PutPayload::from(buf)).await?;
@@ -216,22 +208,27 @@ impl DataStorage for S3Storage {
         })
     }
 
-    async fn write_table_metadata(
+    async fn write_version_metadata(
         &self,
-        table_name: &str,
-        key_columns: &[String],
-        batch_ids: &[u64],
+        metadata: &VersionMetadata,
     ) -> anyhow::Result<()> {
-        let path = self.table_metadata_object_path(table_name);
-
-        let table_meta = serde_json::json!({
-            "key_columns": key_columns,
-            "batch_ids": batch_ids,
-        });
-
-        let bytes = serde_json::to_vec_pretty(&table_meta)?;
+        let path = self.version_metadata_object_path();
+        let bytes = serde_json::to_vec_pretty(metadata)?;
         self.store.put(&path, PutPayload::from(bytes)).await?;
         Ok(())
+    }
+
+    async fn read_version_metadata(&self) -> anyhow::Result<Option<VersionMetadata>> {
+        let path = self.version_metadata_object_path();
+        let get_result = match self.store.get(&path).await {
+            Ok(r) => r,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+
+        let bytes = get_result.bytes().await?;
+        let metadata: VersionMetadata = serde_json::from_slice(&bytes)?;
+        Ok(Some(metadata))
     }
 
     async fn list_batches(&self, table_name: &str) -> anyhow::Result<Vec<String>> {
@@ -246,30 +243,6 @@ impl DataStorage for S3Storage {
             .collect();
 
         Ok(paths)
-    }
-
-    async fn read_batch_ids(&self, table_name: &str) -> anyhow::Result<VecDeque<u64>> {
-        let metadata_path = self.table_metadata_object_path(table_name);
-        let get_result = match self.store.get(&metadata_path).await {
-            Ok(r) => r,
-            Err(object_store::Error::NotFound { .. }) => return Ok(VecDeque::new()),
-            Err(e) => return Err(e.into()),
-        };
-
-        let bytes = get_result.bytes().await?;
-        let table_meta: serde_json::Value = serde_json::from_slice(&bytes)?;
-
-        let Some(ids_array) = table_meta.get("batch_ids").and_then(|v| v.as_array()) else {
-            return Ok(VecDeque::new());
-        };
-
-        let mut ids: Vec<u64> = ids_array.iter().filter_map(|v| v.as_u64()).collect();
-        ids.sort_unstable();
-        Ok(VecDeque::from(ids))
-    }
-
-    async fn read_key_columns(&self, table_name: &str) -> anyhow::Result<Vec<String>> {
-        self.read_key_columns_from_metadata(table_name).await
     }
 
     async fn read_batch(
@@ -297,7 +270,7 @@ impl DataStorage for S3Storage {
             batches.push(batch);
         }
 
-        let key_columns = self.read_key_columns_from_metadata(table_name).await?;
+        let key_columns = self.read_key_columns(table_name).await?;
 
         Ok(Some(ReadResult {
             batches,

--- a/crates/data-generation/src/version.rs
+++ b/crates/data-generation/src/version.rs
@@ -1,0 +1,87 @@
+/*
+Copyright 2024-2025 The Spice.ai OSS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//! Version metadata for data generation.
+//!
+//! Each generation run produces a `version.json` file stored at
+//! `{prefix}/{scenario}/{version}/version.json` that captures all
+//! configuration and table metadata for that version.
+
+use std::collections::HashMap;
+
+use arrow::datatypes::SchemaRef;
+use serde::{Deserialize, Serialize};
+
+/// Converts an Arrow [`SchemaRef`] to a JSON-compatible representation
+/// using Arrow's built-in IPC JSON serialization (the "Schema" portion
+/// of the Arrow JSON integration format).
+pub fn arrow_schema_to_json(schema: &SchemaRef) -> serde_json::Value {
+    let json_schema: Vec<serde_json::Value> = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            let mut obj = serde_json::Map::new();
+            obj.insert("name".to_string(), serde_json::Value::String(field.name().clone()));
+            obj.insert("type".to_string(), serde_json::Value::String(format!("{:?}", field.data_type())));
+            obj.insert("nullable".to_string(), serde_json::Value::Bool(field.is_nullable()));
+            serde_json::Value::Object(obj)
+        })
+        .collect();
+    serde_json::Value::Array(json_schema)
+}
+
+/// Top-level metadata persisted as `version.json` in the version directory.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionMetadata {
+    /// The version identifier.
+    pub version: u64,
+    /// The scenario name (e.g. "tpch").
+    pub scenario: String,
+    /// The scale factor used for data generation.
+    pub scale_factor: f64,
+    /// Number of generation steps (partitions).
+    pub num_steps: u16,
+    /// The dataset type (e.g. "tpch", "simple_sequence").
+    pub dataset_type: String,
+    /// Mutation configuration used during generation.
+    pub mutations: MutationsMetadata,
+    /// Per-table metadata, keyed by table name.
+    pub tables: HashMap<String, TableMetadata>,
+}
+
+/// Mutation configuration stored in version metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MutationsMetadata {
+    /// Ratio of rows that are updates (0.0–1.0).
+    pub update_ratio: f64,
+    /// Ratio of rows that are deletes (0.0–1.0).
+    pub delete_ratio: f64,
+}
+
+/// Per-table metadata stored inside `version.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableMetadata {
+    /// The table name.
+    pub name: String,
+    /// The Arrow schema serialized as JSON (industry-standard field descriptions).
+    pub schema: serde_json::Value,
+    /// The time column name appended during rehydration.
+    pub time_column: String,
+    /// Primary key column names (may be empty for append-only tables).
+    pub key_columns: Vec<String>,
+    /// The batch IDs that were successfully written for this table.
+    pub batch_ids: Vec<u64>,
+}

--- a/crates/data-generation/src/version.rs
+++ b/crates/data-generation/src/version.rs
@@ -34,9 +34,18 @@ pub fn arrow_schema_to_json(schema: &SchemaRef) -> serde_json::Value {
         .iter()
         .map(|field| {
             let mut obj = serde_json::Map::new();
-            obj.insert("name".to_string(), serde_json::Value::String(field.name().clone()));
-            obj.insert("type".to_string(), serde_json::Value::String(format!("{:?}", field.data_type())));
-            obj.insert("nullable".to_string(), serde_json::Value::Bool(field.is_nullable()));
+            obj.insert(
+                "name".to_string(),
+                serde_json::Value::String(field.name().clone()),
+            );
+            obj.insert(
+                "type".to_string(),
+                serde_json::Value::String(format!("{:?}", field.data_type())),
+            );
+            obj.insert(
+                "nullable".to_string(),
+                serde_json::Value::Bool(field.is_nullable()),
+            );
             serde_json::Value::Object(obj)
         })
         .collect();

--- a/crates/data-generation/src/version.rs
+++ b/crates/data-generation/src/version.rs
@@ -25,6 +25,9 @@ use std::collections::HashMap;
 use arrow::datatypes::SchemaRef;
 use serde::{Deserialize, Serialize};
 
+use crate::config::DatasetConfig;
+use crate::dataset::MutationConfig;
+
 /// Converts an Arrow [`SchemaRef`] to a JSON-compatible representation
 /// using Arrow's built-in IPC JSON serialization (the "Schema" portion
 /// of the Arrow JSON integration format).
@@ -69,6 +72,22 @@ pub struct VersionMetadata {
     pub mutations: MutationsMetadata,
     /// Per-table metadata, keyed by table name.
     pub tables: HashMap<String, TableMetadata>,
+}
+
+impl VersionMetadata {
+    /// Creates a [`DatasetConfig`] from the stored version metadata.
+    pub fn dataset_config(&self) -> DatasetConfig {
+        DatasetConfig {
+            dataset_type: self.dataset_type.clone(),
+            scale_factor: self.scale_factor,
+            num_steps: self.num_steps,
+        }
+    }
+
+    /// Creates a [`MutationConfig`] from the stored version metadata.
+    pub fn mutation_config(&self) -> MutationConfig {
+        MutationConfig::new(self.mutations.update_ratio, self.mutations.delete_ratio)
+    }
 }
 
 /// Mutation configuration stored in version metadata.

--- a/crates/etl/README.md
+++ b/crates/etl/README.md
@@ -2,10 +2,14 @@
 
 `etl` reads raw batches from S3, rehydrates records (for example adding a time column), and writes directly to the destination system through a single ADBC sink.
 
+Dataset configuration (dataset type, scale factor, number of steps, mutations) is read automatically from the `version.json` metadata written by the data generation tool.
+
 ## Required arguments
 
 - `--bucket`: S3 bucket containing source batches.
-- `--source-prefix`: S3 prefix for the source dataset.
+- `--prefix`: S3 prefix (the `{prefix}` portion of `{prefix}/{scenario}/{version}/`).
+- `--scenario`: Scenario name (default: `tpch`).
+- `--version`: Version identifier for the data generation to read from.
 - `--adbc-driver`: ADBC driver name (for example `databricks` or `flightsql`).
 - `--adbc-uri`: Connection URI passed as ADBC database option `uri`.
 
@@ -13,11 +17,10 @@
 
 ```bash
 cargo run -p etl -- \
-	--dataset tpch \
-	--scale-factor 1.0 \
-	--num-steps 10 \
+	--scenario tpch \
+	--version 1 \
 	--bucket peasee-indexes \
-	--source-prefix raw \
+	--prefix raw \
 	--region us-west-2 \
 	--adbc-driver databricks \
 	--adbc-uri "databricks://token:${DATABRICKS_TOKEN}@${DATABRICKS_ENDPOINT}:443/${DATABRICKS_HTTP_PATH}" \
@@ -28,11 +31,10 @@ cargo run -p etl -- \
 
 ```bash
 cargo run -p etl -- \
-	--dataset tpch \
-	--scale-factor 1.0 \
-	--num-steps 10 \
+	--scenario tpch \
+	--version 1 \
 	--bucket peasee-indexes \
-	--source-prefix raw \
+	--prefix raw \
 	--adbc-driver flightsql \
 	--adbc-uri "grpcs://${SPICE_CLOUD_FLIGHTSQL_HOST}:443"
 ```

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -221,6 +221,19 @@ pub enum DatasetSource {
 }
 
 impl DatasetSource {
+    /// Creates a [`DatasetSource`] from a dataset type string (e.g. from version metadata).
+    ///
+    /// Supported values: `"tpch"`, `"simple_sequence"`.
+    pub fn from_dataset_type(dataset_type: &str) -> anyhow::Result<Self> {
+        match dataset_type {
+            "tpch" => Ok(DatasetSource::Tpch),
+            "simple_sequence" => Ok(DatasetSource::SimpleSequence),
+            other => {
+                anyhow::bail!("Unknown dataset type: {other}. Use 'tpch' or 'simple_sequence'.")
+            }
+        }
+    }
+
     /// Create an [`Arc<dyn Dataset>`] for this source variant using the given
     /// configuration.
     ///

--- a/crates/etl/src/main.rs
+++ b/crates/etl/src/main.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use adbc_client::AdbcConnection;
 use clap::Parser;
-use data_generation::config::{DatasetConfig, TargetConfig};
+use data_generation::config::{DatasetConfig, TargetConfig, build_version_prefix};
 use data_generation::dataset::MutationConfig;
 use data_generation::storage::s3::S3Storage;
 use etl::sink::adbc::AdbcSink;
@@ -31,6 +31,14 @@ use tracing_subscriber::EnvFilter;
     about = "Run an ETL pipeline that reads from S3, rehydrates data, and writes directly to a SUT via ADBC"
 )]
 struct Cli {
+    /// Scenario name (e.g. "tpch") — used in the storage path `{prefix}/{scenario}/{version}/`
+    #[arg(long, default_value = "tpch")]
+    scenario: String,
+
+    /// Version identifier for the data generation to read from.
+    #[arg(long)]
+    version: u64,
+
     /// Dataset type: "tpch" or "simple_sequence"
     #[arg(long, default_value = "tpch")]
     dataset: String,
@@ -47,9 +55,10 @@ struct Cli {
     #[arg(long)]
     bucket: String,
 
-    /// S3 key prefix for source data
+    /// S3 key prefix (the `{prefix}` portion of `{prefix}/{scenario}/{version}/`)
     #[arg(long, default_value = "")]
-    source_prefix: String,
+    prefix: String,
+
     /// AWS region
     #[arg(long)]
     region: Option<String>,
@@ -94,10 +103,13 @@ impl Cli {
         }
     }
 
+    /// Builds the source config with the versioned prefix:
+    /// `{prefix}/{scenario}/{version}`
     fn source_config(&self) -> TargetConfig {
+        let version_prefix = build_version_prefix(&self.prefix, &self.scenario, self.version);
         TargetConfig {
             bucket: self.bucket.clone(),
-            prefix: self.source_prefix.clone(),
+            prefix: version_prefix,
             region: self.region.clone(),
             endpoint: self.endpoint.clone(),
         }
@@ -130,9 +142,11 @@ async fn main() -> anyhow::Result<()> {
             .with_created_at(cli.with_created_at);
 
     tracing::info!(
+        scenario = %cli.scenario,
+        version = cli.version,
         dataset = %cli.dataset,
         bucket = %cli.bucket,
-        source_prefix = %cli.source_prefix,
+        prefix = %cli.prefix,
         adbc_driver = %cli.adbc_driver,
         adbc_schema = ?cli.adbc_schema,
         scale_factor = cli.scale_factor,

--- a/crates/etl/src/main.rs
+++ b/crates/etl/src/main.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 
 use adbc_client::AdbcConnection;
 use clap::Parser;
-use data_generation::config::{DatasetConfig, TargetConfig, build_version_prefix};
-use data_generation::dataset::MutationConfig;
+use data_generation::config::{TargetConfig, build_version_prefix};
+use data_generation::storage::DataStorage;
 use data_generation::storage::s3::S3Storage;
 use etl::sink::adbc::AdbcSink;
 use etl::{DatasetSource, ETLPipeline, PipelineState, StopReason};
@@ -38,18 +38,6 @@ struct Cli {
     /// Version identifier for the data generation to read from.
     #[arg(long)]
     version: u64,
-
-    /// Dataset type: "tpch" or "simple_sequence"
-    #[arg(long, default_value = "tpch")]
-    dataset: String,
-
-    /// Scale factor for data generation
-    #[arg(long, default_value_t = 1.0)]
-    scale_factor: f64,
-
-    /// Number of data generation steps (partitions)
-    #[arg(long, default_value_t = 25)]
-    num_steps: u16,
 
     /// S3 bucket name (used for both source and target)
     #[arg(long)]
@@ -85,24 +73,6 @@ struct Cli {
 }
 
 impl Cli {
-    fn dataset_source(&self) -> anyhow::Result<DatasetSource> {
-        match self.dataset.as_str() {
-            "tpch" => Ok(DatasetSource::Tpch),
-            "simple_sequence" => Ok(DatasetSource::SimpleSequence),
-            other => {
-                anyhow::bail!("Unknown dataset type: {other}. Use 'tpch' or 'simple_sequence'.")
-            }
-        }
-    }
-
-    fn dataset_config(&self) -> DatasetConfig {
-        DatasetConfig {
-            dataset_type: self.dataset.clone(),
-            scale_factor: self.scale_factor,
-            num_steps: self.num_steps,
-        }
-    }
-
     /// Builds the source config with the versioned prefix:
     /// `{prefix}/{scenario}/{version}`
     fn source_config(&self) -> TargetConfig {
@@ -124,18 +94,27 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
-    let dataset_source = cli.dataset_source()?;
-    let dataset_config = cli.dataset_config();
+    let source_config = cli.source_config();
+    let version_prefix = source_config.prefix.clone();
+    let source = Arc::new(S3Storage::new(&source_config)?);
 
-    let source = Arc::new(S3Storage::new(&cli.source_config())?);
+    // Read version metadata to derive dataset config and mutations.
+    let version_metadata = source
+        .read_version_metadata()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!(
+            "No version.json found at {version_prefix}. Was data generation run for this version?"
+        ))?;
+
+    let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
+    let dataset_config = version_metadata.dataset_config();
+    let mutations = version_metadata.mutation_config();
 
     let adbc_conn = AdbcConnection::create(
         &cli.adbc_driver,
         std::collections::HashMap::from([("uri".to_string(), Value::String(cli.adbc_uri.clone()))]),
     )?;
     let target = Arc::new(AdbcSink::new(adbc_conn, cli.adbc_schema.clone()));
-
-    let mutations = MutationConfig::new(0.0, 0.0);
 
     let mut pipeline =
         ETLPipeline::new(dataset_source, &dataset_config, source, target, &mutations)?
@@ -144,13 +123,13 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!(
         scenario = %cli.scenario,
         version = cli.version,
-        dataset = %cli.dataset,
+        dataset = %version_metadata.dataset_type,
         bucket = %cli.bucket,
         prefix = %cli.prefix,
         adbc_driver = %cli.adbc_driver,
         adbc_schema = ?cli.adbc_schema,
-        scale_factor = cli.scale_factor,
-        num_steps = cli.num_steps,
+        scale_factor = version_metadata.scale_factor,
+        num_steps = version_metadata.num_steps,
         "Starting ETL pipeline"
     );
 

--- a/crates/etl/src/main.rs
+++ b/crates/etl/src/main.rs
@@ -99,12 +99,11 @@ async fn main() -> anyhow::Result<()> {
     let source = Arc::new(S3Storage::new(&source_config)?);
 
     // Read version metadata to derive dataset config and mutations.
-    let version_metadata = source
-        .read_version_metadata()
-        .await?
-        .ok_or_else(|| anyhow::anyhow!(
+    let version_metadata = source.read_version_metadata().await?.ok_or_else(|| {
+        anyhow::anyhow!(
             "No version.json found at {version_prefix}. Was data generation run for this version?"
-        ))?;
+        )
+    })?;
 
     let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
     let dataset_config = version_metadata.dataset_config();

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -104,9 +104,13 @@ pub struct CommonArgs {
     #[arg(long)]
     pub(crate) etl_bucket: String,
 
-    /// S3 key prefix for the ETL source data
+    /// S3 key prefix (the `{prefix}` portion of `{prefix}/{scenario}/{version}/`)
     #[arg(long, default_value = "")]
-    pub(crate) etl_source_prefix: String,
+    pub(crate) etl_prefix: String,
+
+    /// Version identifier for the data generation to read from.
+    #[arg(long)]
+    pub(crate) etl_version: u64,
 
     /// Base S3 key prefix for the ETL target (rehydrated) data.
     /// A random suffix is appended automatically to create a unique destination per run.

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -125,17 +125,9 @@ pub struct CommonArgs {
     #[arg(long)]
     pub(crate) etl_endpoint: Option<String>,
 
-    /// Number of ETL data generation steps (partitions)
-    #[arg(long, default_value_t = 25)]
-    pub(crate) etl_num_steps: u16,
-
     /// Table format propagated through ETL dataset metadata and adapters.
     #[arg(long, value_enum, default_value = "parquet")]
     pub(crate) table_format: TableFormat,
-
-    /// Scale factor for the ETL dataset
-    #[arg(long, default_value_t = 1.0)]
-    pub(crate) scale_factor: f64,
 
     /// Append a `__created_at` timestamp column to every batch written to the sink.
     #[arg(long, default_value_t = false)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use adbc_client::AdbcConnection;
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use checkpointer::CheckpointStore;
 use clap::Parser;
-use data_generation::config::{DatasetConfig as GenerationDatasetConfig, TargetConfig};
+use data_generation::config::{DatasetConfig as GenerationDatasetConfig, TargetConfig, build_version_prefix};
 use data_generation::dataset::Dataset;
 use data_generation::dataset::MutationConfig;
 use data_generation::storage::DataStorage;
@@ -93,9 +93,14 @@ async fn run_benchmark(
     let scenario_name = common.scenario.to_string();
     let checkpoint_dir = tempfile::tempdir()?;
 
+    let version_prefix = build_version_prefix(
+        &common.etl_prefix,
+        &scenario_name,
+        common.etl_version,
+    );
     let checkpoint_store = CheckpointStore::new(
         &common.etl_bucket,
-        &common.etl_source_prefix,
+        &version_prefix,
         common.etl_region.as_deref(),
         common.etl_endpoint.as_deref(),
     )?;
@@ -238,7 +243,11 @@ async fn main() -> anyhow::Result<()> {
 
     let source_config = TargetConfig {
         bucket: cli.common.etl_bucket.clone(),
-        prefix: cli.common.etl_source_prefix.clone(),
+        prefix: build_version_prefix(
+            &cli.common.etl_prefix,
+            &cli.common.scenario.to_string(),
+            cli.common.etl_version,
+        ),
         region: cli.common.etl_region.clone(),
         endpoint: cli.common.etl_endpoint.clone(),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use checkpointer::CheckpointStore;
 use clap::Parser;
 use data_generation::config::{
-    DatasetConfig as GenerationDatasetConfig, TargetConfig, build_version_prefix,
+    TargetConfig, build_version_prefix,
 };
 use data_generation::dataset::Dataset;
 use data_generation::storage::DataStorage;
@@ -154,9 +154,14 @@ async fn run_benchmark(
     let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
     let generation_config = version_metadata.dataset_config();
     let mutations = version_metadata.mutation_config();
-    let mut pipeline =
-        ETLPipeline::new(dataset_source, &generation_config, source, target, &mutations)?
-            .with_created_at(common.with_created_at);
+    let mut pipeline = ETLPipeline::new(
+        dataset_source,
+        &generation_config,
+        source,
+        target,
+        &mutations,
+    )?
+    .with_created_at(common.with_created_at);
 
     if let Err(e) = system_adapter_client.create_tables(run_id, datasets).await {
         pipeline.cancel();
@@ -242,13 +247,12 @@ async fn main() -> anyhow::Result<()> {
     let source = Arc::new(S3Storage::new(&source_config)?);
 
     // Read version metadata to derive dataset config and mutations.
-    let version_metadata = source
-        .read_version_metadata()
-        .await?
-        .ok_or_else(|| anyhow::anyhow!(
+    let version_metadata = source.read_version_metadata().await?.ok_or_else(|| {
+        anyhow::anyhow!(
             "No version.json found at {}. Was data generation run for this version?",
             source_config.prefix,
-        ))?;
+        )
+    })?;
 
     let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
     let generation_config = version_metadata.dataset_config();

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,9 +24,9 @@ use data_generation::config::{
     DatasetConfig as GenerationDatasetConfig, TargetConfig, build_version_prefix,
 };
 use data_generation::dataset::Dataset;
-use data_generation::dataset::MutationConfig;
 use data_generation::storage::DataStorage;
 use data_generation::storage::s3::S3Storage;
+use data_generation::version::VersionMetadata;
 use etl::sink::adbc::AdbcSink;
 use etl::{DatasetSource, ETLPipeline, PipelineState, StopReason};
 use test_framework::{anyhow, rustls};
@@ -40,7 +40,6 @@ mod scenario;
 
 use crate::args::CommonArgs;
 use crate::commands::connect_system_adapter;
-use crate::scenario::Scenario;
 
 fn create_tables_request_datasets(
     dataset: &Arc<dyn Dataset>,
@@ -85,9 +84,7 @@ async fn run_benchmark(
     system_adapter_client: &mut system_adapter_protocol::Client,
     run_id: uuid::Uuid,
     adbc_driver: system_adapter_protocol::SetupResponse,
-    dataset_source: DatasetSource,
-    generation_config: &GenerationDatasetConfig,
-    mutations: &MutationConfig,
+    version_metadata: &VersionMetadata,
     source: Arc<S3Storage>,
     datasets: HashMap<String, system_adapter_protocol::DatasetConfig>,
 ) -> anyhow::Result<()> {
@@ -153,8 +150,12 @@ async fn run_benchmark(
     println!("ADBC connection established (driver: {})", driver_name);
 
     let target = Arc::new(AdbcSink::new_without_table_creation(adbc_conn, None));
+
+    let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
+    let generation_config = version_metadata.dataset_config();
+    let mutations = version_metadata.mutation_config();
     let mut pipeline =
-        ETLPipeline::new(dataset_source, generation_config, source, target, mutations)?
+        ETLPipeline::new(dataset_source, &generation_config, source, target, &mutations)?
             .with_created_at(common.with_created_at);
 
     if let Err(e) = system_adapter_client.create_tables(run_id, datasets).await {
@@ -226,20 +227,7 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
-    // --- Construct the ETL pipeline ---
-    let dataset_source = match &cli.common.scenario {
-        Scenario::TPCH => DatasetSource::Tpch,
-    };
-
-    let generation_config = GenerationDatasetConfig {
-        dataset_type: match &dataset_source {
-            DatasetSource::Tpch => "tpch".to_string(),
-            DatasetSource::SimpleSequence => "simple_sequence".to_string(),
-        },
-        scale_factor: cli.common.scale_factor,
-        num_steps: cli.common.etl_num_steps,
-    };
-
+    // --- Connect to S3 and read version metadata ---
     let source_config = TargetConfig {
         bucket: cli.common.etl_bucket.clone(),
         prefix: build_version_prefix(
@@ -253,6 +241,19 @@ async fn main() -> anyhow::Result<()> {
 
     let source = Arc::new(S3Storage::new(&source_config)?);
 
+    // Read version metadata to derive dataset config and mutations.
+    let version_metadata = source
+        .read_version_metadata()
+        .await?
+        .ok_or_else(|| anyhow::anyhow!(
+            "No version.json found at {}. Was data generation run for this version?",
+            source_config.prefix,
+        ))?;
+
+    let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
+    let generation_config = version_metadata.dataset_config();
+    let mutations = version_metadata.mutation_config();
+
     // --- Connect to the system adapter ---
     let mut system_adapter_client = match connect_system_adapter(&cli.common).await {
         Ok(system_adapter_client) => system_adapter_client,
@@ -262,7 +263,6 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let run_id = uuid::Uuid::new_v4();
-    let mutations = MutationConfig::new(0.0, 0.0);
 
     let setup_dataset = dataset_source.create(
         &generation_config,
@@ -294,9 +294,7 @@ async fn main() -> anyhow::Result<()> {
         &mut system_adapter_client,
         run_id,
         adbc_driver,
-        dataset_source,
-        &generation_config,
-        &mutations,
+        &version_metadata,
         source,
         datasets,
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,9 +20,7 @@ use adbc_client::AdbcConnection;
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use checkpointer::CheckpointStore;
 use clap::Parser;
-use data_generation::config::{
-    TargetConfig, build_version_prefix,
-};
+use data_generation::config::{TargetConfig, build_version_prefix};
 use data_generation::dataset::Dataset;
 use data_generation::storage::DataStorage;
 use data_generation::storage::s3::S3Storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,9 @@ use adbc_client::AdbcConnection;
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use checkpointer::CheckpointStore;
 use clap::Parser;
-use data_generation::config::{DatasetConfig as GenerationDatasetConfig, TargetConfig, build_version_prefix};
+use data_generation::config::{
+    DatasetConfig as GenerationDatasetConfig, TargetConfig, build_version_prefix,
+};
 use data_generation::dataset::Dataset;
 use data_generation::dataset::MutationConfig;
 use data_generation::storage::DataStorage;
@@ -93,11 +95,8 @@ async fn run_benchmark(
     let scenario_name = common.scenario.to_string();
     let checkpoint_dir = tempfile::tempdir()?;
 
-    let version_prefix = build_version_prefix(
-        &common.etl_prefix,
-        &scenario_name,
-        common.etl_version,
-    );
+    let version_prefix =
+        build_version_prefix(&common.etl_prefix, &scenario_name, common.etl_version);
     let checkpoint_store = CheckpointStore::new(
         &common.etl_bucket,
         &version_prefix,


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the format of data generation to:
  1. Persist the mutation config for a particular data generation. This avoids user-input errors of specifying the incorrect mutation config for the same data generation in later stages (like during checkpointing, or ETL, or spicebench)
  2. Store more information about the generated data in a single metadata `version.json` instead of having the data split across many small metadata files.
  3. Store multiple versions of data generations for the same scenario with different generation characteristics (different mutations config, scale factor, step count, etc)
  4. Changes the storage format of data versions to exist at a base root like `{prefix}/{scenario}/{version}/` and `version.json`, `checkpoints/`, and `tables/`
