### PR TITLE
ci: parallelize cargo check and cargo test

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
               - '.github/workflows/pr.yml'
 
   check:
-    name: cargo check + test
+    name: cargo check
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: changes
@@ -50,6 +50,20 @@ jobs:
 
       - name: cargo check
         run: make check
+
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91
 
       - name: cargo test
         run: make test


### PR DESCRIPTION
## Summary
- Split the single `cargo check + test` job into two independent jobs (`check` and `test`)
- Both jobs depend only on the `changes` job, so they run concurrently on separate runners
- Reduces overall CI wall time for PRs

## Test plan
- [x] Verify both `check` and `test` jobs appear and run in parallel on this PR