### PR TITLE
feat: System adapter SetupResponse supports specifying catalog/namespace path

### DIFF
--- a/crates/system-adapter-protocol/src/client.rs
+++ b/crates/system-adapter-protocol/src/client.rs
@@ -181,11 +181,13 @@ impl Client {
         run_id: uuid::Uuid,
         metadata: std::collections::HashMap<String, serde_json::Value>,
         datasets: std::collections::HashMap<String, crate::DatasetConfig>,
+        etl_sink_type: Option<crate::EtlSinkType>,
     ) -> Result<crate::SetupResponse> {
         let request = crate::SetupRequest {
             run_id,
             metadata,
             datasets,
+            etl_sink_type,
         };
         let rpc_request = JsonRpcRequest::new(1, crate::methods::SETUP, request);
         let response = self.call_typed(rpc_request).await?;

--- a/crates/system-adapter-protocol/src/lib.rs
+++ b/crates/system-adapter-protocol/src/lib.rs
@@ -77,6 +77,7 @@ limitations under the License.
 //!         Ok(SetupResponse {
 //!             driver: AdbcDriver::Flightsql,
 //!             db_kwargs: HashMap::new(),
+//!             catalog_namespace: None,
 //!         })
 //!     }
 //!
@@ -169,6 +170,10 @@ pub struct SetupResponse {
     pub driver: AdbcDriver,
     /// Driver-specific connection parameters
     pub db_kwargs: HashMap<String, serde_json::Value>,
+    /// Optional catalog/namespace path where benchmark tables were created
+    /// (e.g. "catalog.schema").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog_namespace: Option<String>,
 }
 /// Request to teardown a benchmark run
 ///

--- a/crates/system-adapter-protocol/src/lib.rs
+++ b/crates/system-adapter-protocol/src/lib.rs
@@ -41,7 +41,9 @@ limitations under the License.
 //!
 //! // Setup a benchmark run
 //! let run_id = Uuid::new_v4();
-//! let setup_response = client.setup(run_id, HashMap::new(), HashMap::new()).await?;
+//! let setup_response = client
+//!     .setup(run_id, HashMap::new(), HashMap::new(), None)
+//!     .await?;
 //!
 //! println!("Driver: {:?}", setup_response.driver);
 //!
@@ -57,7 +59,7 @@ limitations under the License.
 //! # #[cfg(feature = "server")]
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! use system_adapter_protocol::{
-//!     AdbcDriver, DatasetConfig, Handler, Server, SetupResponse, TeardownResponse,
+//!     AdbcDriver, DatasetConfig, EtlSinkType, Handler, Server, SetupResponse, TeardownResponse,
 //! };
 //! use async_trait::async_trait;
 //! use std::collections::HashMap;
@@ -72,8 +74,9 @@ limitations under the License.
 //!         run_id: Uuid,
 //!         metadata: HashMap<String, serde_json::Value>,
 //!         datasets: HashMap<String, DatasetConfig>,
+//!         etl_sink_type: Option<EtlSinkType>,
 //!     ) -> Result<SetupResponse, String> {
-//!         let _ = (metadata, datasets);
+//!         let _ = (metadata, datasets, etl_sink_type);
 //!         Ok(SetupResponse {
 //!             driver: AdbcDriver::Flightsql,
 //!             db_kwargs: HashMap::new(),
@@ -122,6 +125,17 @@ pub enum AdbcDriver {
     Postgresql,
 }
 
+/// ETL sink type used by spicebench for this run.
+///
+/// This is provided to adapters in [`SetupRequest`] so they can optionally
+/// adjust setup behavior based on how data is loaded.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EtlSinkType {
+    Hive,
+    Adbc,
+}
+
 impl std::fmt::Display for AdbcDriver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -161,6 +175,9 @@ pub struct SetupRequest {
     pub metadata: HashMap<String, serde_json::Value>,
     /// Map of dataset name to dataset definition
     pub datasets: HashMap<String, DatasetConfig>,
+    /// Optional ETL sink type selected by spicebench.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub etl_sink_type: Option<EtlSinkType>,
 }
 
 /// Response from setup request containing ADBC connection information

--- a/crates/system-adapter-protocol/src/server.rs
+++ b/crates/system-adapter-protocol/src/server.rs
@@ -17,8 +17,8 @@ limitations under the License.
 //! Server implementations for system adapter JSON-RPC protocol.
 
 use crate::{
-    DatasetConfig, JsonRpcError, JsonRpcResponse, MetricsRequest, MetricsResponse, SetupRequest,
-    SetupResponse, TeardownRequest, TeardownResponse, error_codes, methods,
+    DatasetConfig, EtlSinkType, JsonRpcError, JsonRpcResponse, MetricsRequest, MetricsResponse,
+    SetupRequest, SetupResponse, TeardownRequest, TeardownResponse, error_codes, methods,
 };
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
@@ -76,6 +76,7 @@ pub trait Handler: Send + Sync {
         run_id: Uuid,
         metadata: HashMap<String, serde_json::Value>,
         datasets: HashMap<String, DatasetConfig>,
+        etl_sink_type: Option<EtlSinkType>,
     ) -> std::result::Result<SetupResponse, String>;
 
     /// Teardown a benchmark run
@@ -235,7 +236,7 @@ impl<H: Handler> Server<H> {
         };
         Self::handler_response(
             self.handler
-                .setup(req.run_id, req.metadata, req.datasets)
+                .setup(req.run_id, req.metadata, req.datasets, req.etl_sink_type)
                 .await,
             id,
         )
@@ -285,6 +286,7 @@ mod tests {
             _run_id: Uuid,
             _metadata: HashMap<String, serde_json::Value>,
             _datasets: HashMap<String, DatasetConfig>,
+            _etl_sink_type: Option<EtlSinkType>,
         ) -> std::result::Result<SetupResponse, String> {
             Ok(SetupResponse {
                 driver: crate::AdbcDriver::Flightsql,

--- a/crates/system-adapter-protocol/src/server.rs
+++ b/crates/system-adapter-protocol/src/server.rs
@@ -289,6 +289,7 @@ mod tests {
             Ok(SetupResponse {
                 driver: crate::AdbcDriver::Flightsql,
                 db_kwargs: HashMap::new(),
+                catalog_namespace: None,
             })
         }
 

--- a/crates/test-framework/src/queries/mod.rs
+++ b/crates/test-framework/src/queries/mod.rs
@@ -225,6 +225,10 @@ impl Query {
     /// becomes:
     ///   `SELECT * FROM arrow.customer WHERE c_custkey = 1`
     ///
+    /// Multi-part namespaces are also supported. For example, if `reference_schema`
+    /// is `catalog.schema`, the query becomes:
+    ///   `SELECT * FROM catalog.schema.customer WHERE c_custkey = 1`
+    ///
     /// Uses `DataFusion`'s SQL parser to parse the query, rewrite all table references,
     /// and unparse back to SQL. This works with any valid SQL query.
     ///
@@ -236,6 +240,12 @@ impl Query {
         use sqlparser::ast::{Ident, ObjectNamePart, visit_relations_mut};
         use sqlparser::parser::Parser;
         use std::ops::ControlFlow;
+
+        let namespace_parts: Vec<ObjectNamePart> = reference_schema
+            .split('.')
+            .filter(|part| !part.is_empty())
+            .map(|part| ObjectNamePart::Identifier(Ident::new(part)))
+            .collect();
 
         // Parse the SQL query using sqlparser
         let dialect = sqlparser::dialect::PostgreSqlDialect {};
@@ -262,10 +272,9 @@ impl Query {
         let _ = visit_relations_mut(statement, |table_name| {
             // Only rewrite if the table doesn't already have a schema prefix (single-part name)
             if table_name.0.len() == 1 {
-                // Prepend the reference schema to the table name
-                table_name
-                    .0
-                    .insert(0, ObjectNamePart::Identifier(Ident::new(reference_schema)));
+                for namespace_part in namespace_parts.iter().rev() {
+                    table_name.0.insert(0, namespace_part.clone());
+                }
             }
             ControlFlow::<()>::Continue(())
         });
@@ -990,6 +999,23 @@ mod tests {
             rewritten.sql.as_ref(),
             "SELECT * FROM ref_schema.customer AS c JOIN ref_schema.orders AS o ON c.c_custkey = o.o_custkey"
         );
+    }
+
+    #[test]
+    fn test_rewrite_with_multi_part_namespace() {
+        let query = Query::new(
+            "test_multi_part".into(),
+            "SELECT * FROM customer JOIN orders ON customer.c_custkey = orders.o_custkey".into(),
+            false,
+        );
+
+        let rewritten = query
+            .rewrite_with_reference_schema("main.catalog")
+            .expect("Failed to rewrite query with multi-part namespace");
+
+        let sql = rewritten.sql.as_ref();
+        assert!(sql.contains("main.catalog.customer"));
+        assert!(sql.contains("main.catalog.orders"));
     }
 
     #[test]

--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -290,6 +290,7 @@ pub(crate) async fn run(
     etl_pipeline: &mut ETLPipeline,
     checkpoint_steps: Option<usize>,
     checkpoint_dir: Option<&Path>,
+    query_catalog_namespace: Option<String>,
 ) -> anyhow::Result<()> {
     let metric_attributes = run_metric_attributes(common_args);
 
@@ -378,8 +379,12 @@ pub(crate) async fn run(
     let has_checkpoint_validation =
         common_args.validate_results && checkpoint_steps.is_some() && checkpoint_dir.is_some();
 
-    let (query_set, test_builder) =
-        super::build_test_with_validation(scenario, test_builder).await?;
+    let (query_set, test_builder) = super::build_test_with_validation(
+        scenario,
+        test_builder,
+        query_catalog_namespace.as_deref(),
+    )
+    .await?;
 
     // Build ordered query names for mapping checkpoint query_idx → query name.
     let queries = query_set.get_queries(None, None, None).await?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -50,6 +50,22 @@ pub(crate) fn create_telemetry_with_resource(common: &CommonArgs, resource: Reso
     Telemetry::new_with_resource(&resource, "SPICEAI_BENCHMARK_METRICS_KEY")
 }
 
+fn rewrite_queries_with_catalog_namespace(
+    queries: Vec<test_framework::queries::Query>,
+    query_catalog_namespace: Option<&str>,
+) -> anyhow::Result<Vec<test_framework::queries::Query>> {
+    if let Some(catalog_namespace) = query_catalog_namespace
+        && !catalog_namespace.trim().is_empty()
+    {
+        return queries
+            .into_iter()
+            .map(|query| query.rewrite_with_reference_schema(catalog_namespace))
+            .collect::<anyhow::Result<Vec<_>>>();
+    }
+
+    Ok(queries)
+}
+
 /// Build a test configuration with validation data if applicable
 ///
 /// This is a common helper for bench, throughput, and load tests that:
@@ -64,15 +80,42 @@ pub(crate) fn create_telemetry_with_resource(common: &CommonArgs, resource: Reso
 pub(crate) async fn build_test_with_validation(
     scenario: &Scenario,
     test_builder: NotStarted,
+    query_catalog_namespace: Option<&str>,
 ) -> anyhow::Result<(QuerySet, NotStarted)> {
     let query_set = scenario.load_query_set()?;
-    let queries = query_set.get_queries(None, None, None).await?;
+    let queries = rewrite_queries_with_catalog_namespace(
+        query_set.get_queries(None, None, None).await?,
+        query_catalog_namespace,
+    )?;
 
     let test_builder = test_builder
         .with_query_set(queries)
         .with_query_set_type(query_set.clone());
 
     Ok((query_set, test_builder))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rewrite_queries_with_catalog_namespace() {
+        let queries = vec![test_framework::queries::Query::new(
+            "q1".into(),
+            "SELECT * FROM customer".into(),
+            false,
+        )];
+
+        let rewritten = rewrite_queries_with_catalog_namespace(queries, Some("catalog.schema"))
+            .expect("rewrite should succeed");
+
+        assert_eq!(rewritten.len(), 1);
+        assert_eq!(
+            rewritten[0].sql.as_ref(),
+            "SELECT * FROM catalog.schema.customer"
+        );
+    }
 }
 
 /// Connect to a system adapter based on command-line arguments

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -95,29 +95,6 @@ pub(crate) async fn build_test_with_validation(
     Ok((query_set, test_builder))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_rewrite_queries_with_catalog_namespace() {
-        let queries = vec![test_framework::queries::Query::new(
-            "q1".into(),
-            "SELECT * FROM customer".into(),
-            false,
-        )];
-
-        let rewritten = rewrite_queries_with_catalog_namespace(queries, Some("catalog.schema"))
-            .expect("rewrite should succeed");
-
-        assert_eq!(rewritten.len(), 1);
-        assert_eq!(
-            rewritten[0].sql.as_ref(),
-            "SELECT * FROM catalog.schema.customer"
-        );
-    }
-}
-
 /// Connect to a system adapter based on command-line arguments
 ///
 /// All validation is handled by clap:
@@ -159,4 +136,27 @@ macro_rules! wait_test_and_memory {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rewrite_queries_with_catalog_namespace() {
+        let queries = vec![test_framework::queries::Query::new(
+            "q1".into(),
+            "SELECT * FROM customer".into(),
+            false,
+        )];
+
+        let rewritten = rewrite_queries_with_catalog_namespace(queries, Some("catalog.schema"))
+            .expect("rewrite should succeed");
+
+        assert_eq!(rewritten.len(), 1);
+        assert_eq!(
+            rewritten[0].sql.as_ref(),
+            "SELECT * FROM catalog.schema.customer"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,10 @@ async fn run_benchmark(
     let data_source: Arc<dyn DataStorage> = source.clone();
 
     let mut setup_response_for_run: Option<system_adapter_protocol::SetupResponse> = None;
+    let etl_sink_type = match common.etl_sink {
+        EtlSink::Hive => system_adapter_protocol::EtlSinkType::Hive,
+        EtlSink::Adbc => system_adapter_protocol::EtlSinkType::Adbc,
+    };
 
     let (target, target_config, target_kind, adbc_sink): (
         Arc<dyn Sink>,
@@ -177,6 +181,7 @@ async fn run_benchmark(
                     run_id,
                     setup_metadata.clone(),
                     setup_pipeline.create_tables_request_datasets(),
+                    Some(etl_sink_type),
                 )
                 .await
                 .map_err(|e| anyhow::anyhow!("Failed to setup system adapter: {e}"))?;
@@ -245,6 +250,7 @@ async fn run_benchmark(
                 run_id,
                 setup_metadata,
                 pipeline.create_tables_request_datasets(),
+                Some(etl_sink_type),
             )
             .await
             .map_err(|e| anyhow::anyhow!("Failed to setup system adapter: {e}"))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,7 @@ async fn run_benchmark(
     };
 
     let driver_name = setup_response.driver.to_string();
+    let query_catalog_namespace = setup_response.catalog_namespace.clone();
     let db_kwargs = setup_response.db_kwargs;
 
     let load_conn = match AdbcConnection::create(&driver_name, db_kwargs) {
@@ -273,6 +274,7 @@ async fn run_benchmark(
         &mut pipeline,
         checkpoint_steps,
         Some(checkpoint_dir.path()),
+        query_catalog_namespace,
     )
     .await?;
 

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -1838,6 +1838,7 @@ impl Handler for DatabricksAdapter {
                 Ok(SetupResponse {
                     driver: AdbcDriver::Postgresql,
                     db_kwargs: HashMap::from([("uri".to_string(), Value::String(pg_uri))]),
+                    catalog_namespace: Some(format!("{}.{}", self.config.catalog, self.config.schema)),
                 })
             }
             _ => Ok(SetupResponse {
@@ -1846,6 +1847,7 @@ impl Handler for DatabricksAdapter {
                     "uri".to_string(),
                     Value::String(self.databricks_uri()),
                 )]),
+                catalog_namespace: Some(format!("{}.{}", self.config.catalog, self.config.schema)),
             }),
         }
     }

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -25,7 +25,7 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use system_adapter_protocol::{
-    AdbcDriver, DatasetConfig, Handler, Server, SetupResponse, TeardownResponse,
+    AdbcDriver, DatasetConfig, EtlSinkType, Handler, Server, SetupResponse, TeardownResponse,
 };
 use uuid::Uuid;
 
@@ -1707,7 +1707,9 @@ impl Handler for DatabricksAdapter {
         run_id: Uuid,
         metadata: HashMap<String, Value>,
         datasets: HashMap<String, DatasetConfig>,
+        etl_sink_type: Option<EtlSinkType>,
     ) -> std::result::Result<SetupResponse, String> {
+        let _ = etl_sink_type;
         eprintln!("[databricks-adapter] setup: run_id={run_id}");
         eprintln!("[databricks-adapter] endpoint={}", self.config.endpoint);
 


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Updates the system-adapter-protocol for system adapters to allow specifying the catalog/namespace their tables have been created under after setup.
* Passes the response catalog into `Query::rewrite_with_reference_schema` to update table references to use the returned catalog