### PR TITLE
Improvements for spicebench results validation

### DIFF
--- a/crates/adbc_client/src/lib.rs
+++ b/crates/adbc_client/src/lib.rs
@@ -24,7 +24,7 @@ use adbc_core::{Connection, Database, Driver, LOAD_FLAG_DEFAULT, Optionable, Sta
 use adbc_driver_manager::ManagedDriver;
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Schema};
-use arrow_array::RecordBatch;
+use arrow_array::{Array, RecordBatch, StringArray};
 use arrow_schema::Field;
 use snafu::prelude::*;
 use std::collections::HashMap;
@@ -56,15 +56,21 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub struct AdbcConnection {
     conn: adbc_driver_manager::ManagedConnection,
     downcast_utf8view: bool,
+    resolve_opaque_numerics: bool,
 }
 
 impl AdbcConnection {
     /// Create an `AdbcConnection` from an already-established [`ManagedConnection`].
     #[must_use]
-    pub fn new(conn: adbc_driver_manager::ManagedConnection, downcast_utf8view: bool) -> Self {
+    pub fn new(
+        conn: adbc_driver_manager::ManagedConnection,
+        downcast_utf8view: bool,
+        resolve_opaque_numerics: bool,
+    ) -> Self {
         Self {
             conn,
             downcast_utf8view,
+            resolve_opaque_numerics,
         }
     }
 
@@ -106,7 +112,11 @@ impl AdbcConnection {
             reason: e.to_string(),
         })?;
 
-        Ok(Self::new(conn, driver_name == "databricks"))
+        Ok(Self::new(
+            conn,
+            driver_name == "databricks",
+            driver_name == "postgresql",
+        ))
     }
 
     /// Lightweight check that the connection is still usable.
@@ -122,6 +132,9 @@ impl AdbcConnection {
     }
 
     /// Execute a SQL query and collect all result batches.
+    ///
+    /// Any columns returned with the Arrow opaque extension type for
+    /// PostgreSQL `numeric` are automatically converted to `Decimal128`.
     pub fn query(&mut self, sql: &str) -> Result<Vec<RecordBatch>> {
         let mut stmt = self.conn.new_statement().map_err(|e| Error::ExecuteQuery {
             reason: e.to_string(),
@@ -135,9 +148,15 @@ impl AdbcConnection {
             reason: e.to_string(),
         })?;
 
-        reader
+        let mut batches = reader
             .collect::<std::result::Result<Vec<_>, _>>()
-            .context(ReadBatchSnafu)
+            .context(ReadBatchSnafu)?;
+
+        if self.resolve_opaque_numerics {
+            batches = resolve_opaque_numerics(batches);
+        }
+
+        Ok(batches)
     }
 
     /// Execute a SQL data-modification statement and return the affected row count when provided by the driver.
@@ -274,4 +293,111 @@ fn downcast_utf8view(batch: &RecordBatch) -> RecordBatch {
     }
 
     RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap()
+}
+
+/// Returns `true` if the field uses the Arrow opaque extension type for
+/// PostgreSQL `numeric`.
+fn is_opaque_numeric(field: &Field) -> bool {
+    if !matches!(field.data_type(), DataType::Utf8) {
+        return false;
+    }
+    let metadata = field.metadata();
+    let Some(ext_name) = metadata.get("ARROW:extension:name") else {
+        return false;
+    };
+    if ext_name != "arrow.opaque" {
+        return false;
+    }
+    let Some(ext_meta) = metadata.get("ARROW:extension:metadata") else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(ext_meta)
+        .ok()
+        .and_then(|v| v.get("type_name")?.as_str().map(|s| s == "numeric"))
+        .unwrap_or(false)
+}
+
+/// Determine the maximum decimal scale (digits after the decimal point)
+/// across all non-null values in a string array.
+fn max_decimal_scale(array: &StringArray) -> i8 {
+    let mut scale: i8 = 0;
+    for i in 0..array.len() {
+        if array.is_null(i) {
+            continue;
+        }
+        let val = array.value(i);
+        if let Some(dot_pos) = val.find('.') {
+            let s = (val.len() - dot_pos - 1) as i8;
+            scale = scale.max(s);
+        }
+    }
+    scale
+}
+
+/// Convert columns returned by the PostgreSQL ADBC driver as
+/// `Utf8` with `arrow.opaque` extension metadata for `numeric` to
+/// `Decimal128`, matching the representation used in checkpoint
+/// parquet files.
+///
+/// The scale for each column is inferred from the actual data across
+/// all batches. If casting fails (e.g. the column contains `NaN` or
+/// `inf`), the original `Utf8` column is kept.
+fn resolve_opaque_numerics(batches: Vec<RecordBatch>) -> Vec<RecordBatch> {
+    if batches.is_empty() {
+        return batches;
+    }
+
+    let schema = batches[0].schema();
+    let opaque_cols: Vec<usize> = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter_map(|(i, f)| if is_opaque_numeric(f) { Some(i) } else { None })
+        .collect();
+
+    if opaque_cols.is_empty() {
+        return batches;
+    }
+
+    // Determine the max scale for each opaque numeric column across
+    // all batches so every batch uses a consistent Decimal128 type.
+    let mut scales: Vec<i8> = vec![0; opaque_cols.len()];
+    for batch in &batches {
+        for (j, &col_idx) in opaque_cols.iter().enumerate() {
+            if let Some(arr) = batch.column(col_idx).as_any().downcast_ref::<StringArray>() {
+                scales[j] = scales[j].max(max_decimal_scale(arr));
+            }
+        }
+    }
+
+    batches
+        .into_iter()
+        .map(|batch| {
+            let schema = batch.schema();
+            let mut fields = Vec::with_capacity(schema.fields().len());
+            let mut columns = Vec::with_capacity(schema.fields().len());
+
+            for (i, field) in schema.fields().iter().enumerate() {
+                if let Some(j) = opaque_cols.iter().position(|&idx| idx == i) {
+                    let target_type = DataType::Decimal128(38, scales[j]);
+                    match cast(batch.column(i), &target_type) {
+                        Ok(converted) => {
+                            fields.push(Arc::new(Field::new(
+                                field.name(),
+                                target_type,
+                                field.is_nullable(),
+                            )));
+                            columns.push(converted);
+                            continue;
+                        }
+                        Err(_) => { /* fall through to keep original */ }
+                    }
+                }
+                fields.push(field.clone());
+                columns.push(batch.column(i).clone());
+            }
+
+            RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap()
+        })
+        .collect()
 }

--- a/crates/adbc_client/src/pool.rs
+++ b/crates/adbc_client/src/pool.rs
@@ -46,7 +46,11 @@ pub struct AdbcConnectionManager {
 
 impl AdbcConnectionManager {
     /// Create a new manager from an existing [`ManagedDatabase`].
-    pub fn new(database: ManagedDatabase, downcast_utf8view: bool, resolve_opaque_numerics: bool) -> Self {
+    pub fn new(
+        database: ManagedDatabase,
+        downcast_utf8view: bool,
+        resolve_opaque_numerics: bool,
+    ) -> Self {
         Self {
             database: Arc::new(database),
             downcast_utf8view,
@@ -66,7 +70,11 @@ impl r2d2::ManageConnection for AdbcConnectionManager {
             .map_err(|e| Error::CreateConnection {
                 reason: e.to_string(),
             })?;
-        Ok(AdbcConnection::new(conn, self.downcast_utf8view, self.resolve_opaque_numerics))
+        Ok(AdbcConnection::new(
+            conn,
+            self.downcast_utf8view,
+            self.resolve_opaque_numerics,
+        ))
     }
 
     fn is_valid(&self, conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {
@@ -121,7 +129,8 @@ pub fn create_pool(
             reason: e.to_string(),
         })?;
 
-    let manager = AdbcConnectionManager::new(db, driver_name == "databricks", driver_name == "postgresql");
+    let manager =
+        AdbcConnectionManager::new(db, driver_name == "databricks", driver_name == "postgresql");
 
     r2d2::Pool::builder()
         .max_size(pool_size)

--- a/crates/adbc_client/src/pool.rs
+++ b/crates/adbc_client/src/pool.rs
@@ -41,14 +41,16 @@ const DEFAULT_POOL_SIZE: u32 = 10;
 pub struct AdbcConnectionManager {
     database: Arc<ManagedDatabase>,
     downcast_utf8view: bool,
+    resolve_opaque_numerics: bool,
 }
 
 impl AdbcConnectionManager {
     /// Create a new manager from an existing [`ManagedDatabase`].
-    pub fn new(database: ManagedDatabase, downcast_utf8view: bool) -> Self {
+    pub fn new(database: ManagedDatabase, downcast_utf8view: bool, resolve_opaque_numerics: bool) -> Self {
         Self {
             database: Arc::new(database),
             downcast_utf8view,
+            resolve_opaque_numerics,
         }
     }
 }
@@ -64,7 +66,7 @@ impl r2d2::ManageConnection for AdbcConnectionManager {
             .map_err(|e| Error::CreateConnection {
                 reason: e.to_string(),
             })?;
-        Ok(AdbcConnection::new(conn, self.downcast_utf8view))
+        Ok(AdbcConnection::new(conn, self.downcast_utf8view, self.resolve_opaque_numerics))
     }
 
     fn is_valid(&self, conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {
@@ -119,7 +121,7 @@ pub fn create_pool(
             reason: e.to_string(),
         })?;
 
-    let manager = AdbcConnectionManager::new(db, driver_name == "databricks");
+    let manager = AdbcConnectionManager::new(db, driver_name == "databricks", driver_name == "postgresql");
 
     r2d2::Pool::builder()
         .max_size(pool_size)

--- a/crates/test-framework/src/queries/validation/mod.rs
+++ b/crates/test-framework/src/queries/validation/mod.rs
@@ -148,10 +148,15 @@ fn datatype_equivalent(expected_type: &DataType, actual_type: &DataType) -> bool
         // Existing numeric and string type equivalences
         _ => matches!(
             (expected_type, actual_type),
-            (DataType::Float32, DataType::Float64)
+            (DataType::Decimal128(_, _), DataType::Decimal128(_, _))
+                | (DataType::Float32, DataType::Float64)
                 | (
                     DataType::Float64 | DataType::Int64,
                     DataType::Decimal128(_, _)
+                )
+                | (
+                    DataType::Decimal128(_, _),
+                    DataType::Int64 | DataType::Int32 | DataType::Float64
                 )
                 | (DataType::Int32, DataType::Int64)
                 | (

--- a/crates/test-framework/src/spicetest/datasets/checkpoint_validation.rs
+++ b/crates/test-framework/src/spicetest/datasets/checkpoint_validation.rs
@@ -53,25 +53,34 @@ pub enum ValidationCommand {
 }
 
 /// Per-query validation outcome recorded during a validation window.
+///
+/// Uses a **convergence model**: instead of cumulative pass/fail counts,
+/// tracks a streak of consecutive passes so that transient failures from
+/// sync propagation delay don't permanently taint the result.
 #[derive(Debug, Clone)]
 pub struct QueryValidationOutcome {
     /// The query name.
     pub query_name: Arc<str>,
-    /// Number of times this query was validated successfully.
-    pub pass_count: usize,
-    /// Number of times this query failed validation.
-    pub fail_count: usize,
-    /// The most recent failure reason, if any.
+    /// Total number of validation attempts (for reporting).
+    pub total_attempts: usize,
+    /// Number of consecutive passes ending at the most recent attempt.
+    /// Reset to 0 on any failure.
+    pub consecutive_passes: usize,
+    /// The most recent failure reason, if any (for diagnostics).
     pub last_failure: Option<QueryValidationFailReason>,
 }
 
 /// A snapshot of the current checkpoint validation state, published via a
 /// `watch` channel so the load runner can inspect it at any time.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub enum ValidationStatus {
     /// Checkpoint validation is not currently active.
-    #[default]
-    Inactive,
+    Inactive {
+        /// Number of complete query-set iterations that have finished.
+        /// Tracked even when validation is inactive so the load runner
+        /// can wait for at least one iteration before shutting down.
+        completed_iterations: usize,
+    },
     /// Checkpoint validation is active for the given checkpoint index.
     Active {
         /// The checkpoint index being validated.
@@ -88,44 +97,33 @@ pub enum ValidationStatus {
     },
 }
 
-impl ValidationStatus {
-    /// Returns `true` if all validated queries have passed (no failures).
-    #[must_use]
-    pub fn all_passed(&self) -> bool {
-        match self {
-            ValidationStatus::Inactive => true,
-            ValidationStatus::Active { outcomes, .. } => outcomes.iter().all(|o| o.fail_count == 0),
+impl Default for ValidationStatus {
+    fn default() -> Self {
+        Self::Inactive {
+            completed_iterations: 0,
         }
     }
+}
 
+impl ValidationStatus {
     /// Returns `true` if the validation has converged — i.e. at least one
     /// complete query-set iteration finished with every query passing.
     #[must_use]
     pub fn converged(&self) -> bool {
         match self {
-            ValidationStatus::Inactive => false,
+            ValidationStatus::Inactive { .. } => false,
             ValidationStatus::Active { converged, .. } => *converged,
         }
     }
 
-    /// Returns the total number of validation failures across all queries.
-    #[must_use]
-    pub fn total_failures(&self) -> usize {
-        match self {
-            ValidationStatus::Inactive => 0,
-            ValidationStatus::Active { outcomes, .. } => {
-                outcomes.iter().map(|o| o.fail_count).sum()
-            }
-        }
-    }
-
-    /// Returns the number of completed query-set iterations since
-    /// validation was enabled, or `0` if inactive.
+    /// Returns the number of completed query-set iterations.
     #[must_use]
     pub fn completed_iterations(&self) -> usize {
         match self {
-            ValidationStatus::Inactive => 0,
-            ValidationStatus::Active {
+            ValidationStatus::Inactive {
+                completed_iterations,
+            }
+            | ValidationStatus::Active {
                 completed_iterations,
                 ..
             } => *completed_iterations,
@@ -163,7 +161,7 @@ pub struct ValidationWorkerHandles {
 ///   commands and publish its validation status.
 pub fn create_validation_channels() -> (ValidationController, ValidationWorkerHandles) {
     let (command_tx, command_rx) = tokio::sync::watch::channel(None);
-    let (status_tx, status_rx) = tokio::sync::watch::channel(ValidationStatus::Inactive);
+    let (status_tx, status_rx) = tokio::sync::watch::channel(ValidationStatus::default());
 
     (
         ValidationController {

--- a/crates/test-framework/src/spicetest/datasets/worker.rs
+++ b/crates/test-framework/src/spicetest/datasets/worker.rs
@@ -148,7 +148,7 @@ impl CheckpointValidationState {
                 self.current_iteration_results.clear();
                 self.converged = false;
                 eprintln!("Checkpoint validation disabled");
-                let _ = self.status_tx.send(ValidationStatus::Inactive);
+                self.publish_status();
                 true
             }
             None => false,
@@ -228,15 +228,16 @@ impl CheckpointValidationState {
             .entry(Arc::clone(query_name))
             .or_insert_with(|| QueryValidationOutcome {
                 query_name: Arc::clone(query_name),
-                pass_count: 0,
-                fail_count: 0,
+                total_attempts: 0,
+                consecutive_passes: 0,
                 last_failure: None,
             });
 
+        outcome.total_attempts += 1;
         if passed {
-            outcome.pass_count += 1;
+            outcome.consecutive_passes += 1;
         } else {
-            outcome.fail_count += 1;
+            outcome.consecutive_passes = 0;
             outcome.last_failure = failure;
         }
     }
@@ -273,11 +274,17 @@ impl CheckpointValidationState {
     }
 
     fn publish_status(&self) {
-        let status = ValidationStatus::Active {
-            checkpoint_idx: self.checkpoint_idx,
-            outcomes: self.outcomes.values().cloned().collect(),
-            completed_iterations: self.completed_iterations,
-            converged: self.converged,
+        let status = if self.active {
+            ValidationStatus::Active {
+                checkpoint_idx: self.checkpoint_idx,
+                outcomes: self.outcomes.values().cloned().collect(),
+                completed_iterations: self.completed_iterations,
+                converged: self.converged,
+            }
+        } else {
+            ValidationStatus::Inactive {
+                completed_iterations: self.completed_iterations,
+            }
         };
         let _ = self.status_tx.send(status);
     }

--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -559,21 +559,23 @@ pub(crate) async fn run(
                                     } = &status
                                     {
                                         let total_pass: usize =
-                                            outcomes.iter().map(|o| o.pass_count).sum();
-                                        let total_fail: usize =
-                                            outcomes.iter().map(|o| o.fail_count).sum();
+                                            outcomes.iter().map(|o| o.consecutive_passes).sum();
+                                        let total_fail: usize = outcomes
+                                            .iter()
+                                            .filter(|o| o.consecutive_passes == 0 && o.total_attempts > 0)
+                                            .count();
                                         println!(
                                             "Checkpoint {idx} validation ({iters} iterations, converged={converged}): {} queries, {total_pass} pass, {total_fail} fail",
                                             outcomes.len()
                                         );
                                         if total_fail > 0 {
                                             for o in outcomes {
-                                                if o.fail_count > 0 {
+                                                if o.consecutive_passes == 0 && o.total_attempts > 0 {
                                                     eprintln!(
-                                                        "  FAIL - query '{}': {} pass, {} fail, last failure: {:?}",
+                                                        "  FAIL - query '{}': {} attempts, {} consecutive passes, last failure: {:?}",
                                                         o.query_name,
-                                                        o.pass_count,
-                                                        o.fail_count,
+                                                        o.total_attempts,
+                                                        o.consecutive_passes,
                                                         o.last_failure
                                                     );
                                                 }


### PR DESCRIPTION
## 🗣 Description

- **Convergence-based validation**: Changed from cumulative pass/fail counting to a convergence model — validation succeeds once a full query-set iteration passes, tolerating transient failures from Lakebase sync propagation delay.

- **Fix validation race condition**: `publish_status()` always sent `Active` status even when validation was inactive, causing the polling loop to exit immediately with 0 queries validated. Now correctly sends `Inactive` when not active.             

- **Fix PostgreSQL NUMERIC** type handling: PostgreSQL ADBC driver returns NUMERIC columns as `Utf8` with `arrow.opaque` extension metadata. Added `resolve_opaque_numerics` to automatically cast these to `Decimal128` (enabled only for the postgresql driver).

- **Add schema equivalence rules**: 
    * `Decimal128 ↔ Decimal128` (different precision/scale), 
    * `Decimal128 ↔ Int64/Int32/Float64` (Checkpointer exports `COUNT(*)` as `Decimal128(38,0)`, PostgreSQL returns `Int64`).
