### PR TITLE
Derive ingestion_rows_per_sec in spicebench when not provided by system adapter

### DIFF
--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -79,6 +79,8 @@ fn record_sut_metrics(
     prev_disk_write_bytes: &mut Option<u64>,
     prev_disk_read_iops: &mut Option<u64>,
     prev_disk_write_iops: &mut Option<u64>,
+    prev_rows_ingested: &mut Option<u64>,
+    last_scrape_time: &mut Option<std::time::Instant>,
 ) {
     // Resource metrics are cumulative counters; record the delta since last scrape
     if let Some(cpu) = response.resource.cpu_usage_percent {
@@ -129,9 +131,25 @@ fn record_sut_metrics(
     if let Some(v) = response.ingestion.bytes_ingested {
         instruments.ingestion_bytes_total.record(v, attributes);
     }
+    // Use adapter-provided rows_per_sec if available; otherwise derive it
+    // from the delta in rows_ingested since the last scrape.
     if let Some(v) = response.ingestion.rows_per_sec {
         crate::metrics::INGESTION_ROWS_PER_SEC.record(v, attributes);
+    } else if let Some(current_rows) = response.ingestion.rows_ingested
+        && let Some(prev_rows) = *prev_rows_ingested
+        && let Some(prev_time) = *last_scrape_time
+    {
+        let elapsed_secs = prev_time.elapsed().as_secs_f64();
+        if elapsed_secs > 0.0 {
+            let rows_per_sec = current_rows.saturating_sub(prev_rows) as f64 / elapsed_secs;
+            crate::metrics::INGESTION_ROWS_PER_SEC.record(rows_per_sec, attributes);
+        }
     }
+    // Update tracking state for the next scrape
+    if let Some(v) = response.ingestion.rows_ingested {
+        *prev_rows_ingested = Some(v);
+    }
+    *last_scrape_time = Some(std::time::Instant::now());
     if let Some(v) = response.ingestion.active_connections {
         crate::metrics::ACTIVE_CONNECTIONS.record(v, attributes);
     }
@@ -156,6 +174,8 @@ fn spawn_sut_metrics_scraper(
         let mut prev_cpu_usage_seconds: Option<f64> = None;
         let mut prev_disk_read_iops: Option<u64> = None;
         let mut prev_disk_write_iops: Option<u64> = None;
+        let mut prev_rows_ingested: Option<u64> = None;
+        let mut last_scrape_time: Option<std::time::Instant> = None;
         let mut ticker = tokio::time::interval(interval);
         loop {
             tokio::select! {
@@ -173,6 +193,8 @@ fn spawn_sut_metrics_scraper(
                                 &mut prev_disk_write_bytes,
                                 &mut prev_disk_read_iops,
                                 &mut prev_disk_write_iops,
+                                &mut prev_rows_ingested,
+                                &mut last_scrape_time,
                             );
                             last_response = Some(resp);
                         }
@@ -194,6 +216,8 @@ fn spawn_sut_metrics_scraper(
                             &mut prev_disk_write_bytes,
                             &mut prev_disk_read_iops,
                             &mut prev_disk_write_iops,
+                            &mut prev_rows_ingested,
+                            &mut last_scrape_time,
                         );
                         last_response = Some(resp);
                     }


### PR DESCRIPTION
When the system adapter's MetricsResponse includes rows_per_sec, it is used as before. When it is None, spicebench now computes it from the delta in rows_ingested between consecutive scrapes.