### PR TITLE
Add Lakebase PG metrics collection (disk I/O, ingestion, connections)

### DIFF
--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -1673,11 +1673,10 @@ impl DatabricksAdapter {
     /// Collect Lakebase PG metrics using delta approach for I/O.
     async fn collect_lakebase_metrics(
         &self,
-        lakebase_config: &LakebaseConfig,
+        _lakebase_config: &LakebaseConfig,
         baseline: Option<&PgIoBaseline>,
     ) -> Result<MetricsResponse> {
         let client = self.connect_lakebase_pg().await?;
-        let schema = &lakebase_config.schema;
 
         // active_connections
         let active_connections: Option<u64> = client
@@ -1689,25 +1688,29 @@ impl DatabricksAdapter {
             .ok()
             .map(|row| row.get::<_, i64>(0) as u64);
 
-        // rows_ingested (per-schema, counters start at 0 since tables are recreated)
-        let rows_ingested: Option<u64> = client
-            .query_one(
-                "SELECT COALESCE(SUM(n_tup_ins), 0)::bigint FROM pg_stat_user_tables WHERE schemaname = $1",
-                &[&schema],
-            )
-            .await
-            .ok()
-            .map(|row| row.get::<_, i64>(0) as u64);
-
-        // bytes_ingested (per-schema)
-        let bytes_ingested: Option<u64> = client
-            .query_one(
-                "SELECT COALESCE(SUM(pg_total_relation_size(schemaname || '.' || tablename)), 0)::bigint FROM pg_tables WHERE schemaname = $1",
-                &[&schema],
-            )
-            .await
-            .ok()
-            .map(|row| row.get::<_, i64>(0) as u64);
+        // rows_ingested / bytes_ingested: not available on Lakebase.
+        // The synced table pipeline writes at the storage layer, bypassing PG's
+        // tuple tracking (n_tup_ins) and relation size accounting
+        // (pg_total_relation_size), so both are always zero.
+        //
+        // let _schema = &lakebase_config.schema;
+        // let rows_ingested: Option<u64> = client
+        //     .query_one(
+        //         "SELECT COALESCE(SUM(n_tup_ins), 0)::bigint FROM pg_stat_user_tables WHERE schemaname = $1",
+        //         &[&schema],
+        //     )
+        //     .await
+        //     .ok()
+        //     .map(|row| row.get::<_, i64>(0) as u64);
+        //
+        // let bytes_ingested: Option<u64> = client
+        //     .query_one(
+        //         "SELECT COALESCE(SUM(pg_total_relation_size(schemaname || '.' || tablename)), 0)::bigint FROM pg_tables WHERE schemaname = $1",
+        //         &[&schema],
+        //     )
+        //     .await
+        //     .ok()
+        //     .map(|row| row.get::<_, i64>(0) as u64);
 
         let mut resource = ResourceMetrics::default();
 
@@ -1732,8 +1735,8 @@ impl DatabricksAdapter {
             resource,
             ingestion: IngestionMetrics {
                 active_connections,
-                rows_ingested,
-                bytes_ingested,
+                rows_ingested: None,
+                bytes_ingested: None,
                 ..Default::default()
             },
         })
@@ -1889,11 +1892,6 @@ impl DatabricksAdapter {
         };
 
         eprintln!("[databricks-adapter] generating fresh Lakebase PG OAuth token");
-
-        eprintln!(
-            "[databricks-adapter] generate_lakebase_pg_token: url={}, \ntoken={}, \npayload={:#?}",
-            url, self.config.token, payload
-        );
 
         let response = self
             .client

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -226,6 +226,13 @@ impl TableFormat {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct PgIoBaseline {
+    reads: i64,
+    writes: i64,
+    op_bytes: i64,
+}
+
 #[derive(Debug, Clone)]
 struct RunState {
     table_format: TableFormat,
@@ -236,6 +243,10 @@ struct RunState {
     cluster_created_by_adapter: bool,
     /// Epoch millis when the run was set up (for Query History time-range filtering).
     started_at_ms: u64,
+    /// Baseline `pg_stat_io` counters snapshotted after setup. Because `pg_stat_reset()` is
+    /// denied on Lakebase (requires elevated privileges), server-wide I/O counters accumulate across
+    /// runs. We subtract these baseline values at each metrics scrape to get per-run disk read/write bytes.
+    pg_io_baseline: Option<PgIoBaseline>,
 }
 
 struct DatabricksAdapter {
@@ -1610,11 +1621,8 @@ impl DatabricksAdapter {
         }
     }
 
-    async fn delete_lakebase_pg_tables(
-        &self,
-        table_names: &[String],
-        lakebase_config: &LakebaseConfig,
-    ) -> Result<()> {
+    /// Connect to Lakebase PG with TLS. Returns the client (spawns the connection task).
+    async fn connect_lakebase_pg(&self) -> Result<tokio_postgres::Client> {
         let mut root_store = rustls::RootCertStore::empty();
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
         let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
@@ -1631,6 +1639,105 @@ impl DatabricksAdapter {
             .await
             .map_err(|e| anyhow!("Failed to connect to Lakebase PG: {e}"))?;
         tokio::spawn(connection);
+        Ok(client)
+    }
+
+    /// Snapshot pg_stat_io baseline for delta-based I/O metrics.
+    async fn snapshot_pg_io_baseline(&self) -> Result<PgIoBaseline> {
+        let client = self.connect_lakebase_pg().await?;
+        let mut baseline = PgIoBaseline::default();
+
+        let row = client
+            .query_one(
+                "SELECT COALESCE(SUM(reads), 0)::bigint, COALESCE(SUM(writes), 0)::bigint, COALESCE(MIN(op_bytes), 8192)::bigint FROM pg_stat_io",
+                &[],
+            )
+            .await?;
+        baseline.reads = row.get::<_, i64>(0);
+        baseline.writes = row.get::<_, i64>(1);
+        baseline.op_bytes = row.get::<_, i64>(2);
+        eprintln!(
+            "[databricks-adapter] pg_stat_io baseline: reads={}, writes={}, op_bytes={}",
+            baseline.reads, baseline.writes, baseline.op_bytes
+        );
+        Ok(baseline)
+    }
+
+    /// Collect Lakebase PG metrics using delta approach for I/O.
+    async fn collect_lakebase_metrics(
+        &self,
+        lakebase_config: &LakebaseConfig,
+        baseline: Option<&PgIoBaseline>,
+    ) -> Result<MetricsResponse> {
+        let client = self.connect_lakebase_pg().await?;
+        let schema = &lakebase_config.schema;
+
+        // active_connections
+        let active_connections: Option<u64> = client
+            .query_one(
+                "SELECT count(*)::bigint FROM pg_stat_activity WHERE state = 'active'",
+                &[],
+            )
+            .await
+            .ok()
+            .map(|row| row.get::<_, i64>(0) as u64);
+
+        // rows_ingested (per-schema, counters start at 0 since tables are recreated)
+        let rows_ingested: Option<u64> = client
+            .query_one(
+                "SELECT COALESCE(SUM(n_tup_ins), 0)::bigint FROM pg_stat_user_tables WHERE schemaname = $1",
+                &[&schema],
+            )
+            .await
+            .ok()
+            .map(|row| row.get::<_, i64>(0) as u64);
+
+        // bytes_ingested (per-schema)
+        let bytes_ingested: Option<u64> = client
+            .query_one(
+                "SELECT COALESCE(SUM(pg_total_relation_size(schemaname || '.' || tablename)), 0)::bigint FROM pg_tables WHERE schemaname = $1",
+                &[&schema],
+            )
+            .await
+            .ok()
+            .map(|row| row.get::<_, i64>(0) as u64);
+
+        let mut resource = ResourceMetrics::default();
+
+        // I/O metrics via delta approach against pg_stat_io
+        if let Some(base) = baseline {
+            if let Ok(row) = client
+                .query_one(
+                    "SELECT COALESCE(SUM(reads), 0)::bigint, COALESCE(SUM(writes), 0)::bigint, COALESCE(MIN(op_bytes), 8192)::bigint FROM pg_stat_io",
+                    &[],
+                )
+                .await
+            {
+                let reads: i64 = row.get(0);
+                let writes: i64 = row.get(1);
+                let op_bytes: i64 = row.get(2);
+                resource.disk_read_bytes = Some(((reads - base.reads) * op_bytes).max(0) as u64);
+                resource.disk_write_bytes = Some(((writes - base.writes) * op_bytes).max(0) as u64);
+            }
+        }
+
+        Ok(MetricsResponse {
+            resource,
+            ingestion: IngestionMetrics {
+                active_connections,
+                rows_ingested,
+                bytes_ingested,
+                ..Default::default()
+            },
+        })
+    }
+
+    async fn delete_lakebase_pg_tables(
+        &self,
+        table_names: &[String],
+        lakebase_config: &LakebaseConfig,
+    ) -> Result<()> {
+        let client = self.connect_lakebase_pg().await?;
 
         for table_name in table_names {
             let sql = format!(
@@ -1648,23 +1755,7 @@ impl DatabricksAdapter {
     }
 
     async fn create_lakebase_pg_indexes(&self, lakebase_config: &LakebaseConfig) -> Result<()> {
-        let mut root_store = rustls::RootCertStore::empty();
-        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-
-        let tls_config = rustls::ClientConfig::builder_with_provider(Arc::new(
-            rustls::crypto::ring::default_provider(),
-        ))
-        .with_safe_default_protocol_versions()
-        .map_err(|e| anyhow!("Failed to configure TLS: {e}"))?
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
-        let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
-
-        let pg_uri = self.lakebase_pg_uri().await?;
-        let (client, connection) = tokio_postgres::connect(&pg_uri, tls)
-            .await
-            .map_err(|e| anyhow!("Failed to connect to Lakebase PG: {e}"))?;
-        tokio::spawn(connection);
+        let client = self.connect_lakebase_pg().await?;
 
         let index_stmts = [
             format!(
@@ -2053,6 +2144,7 @@ impl Handler for DatabricksAdapter {
                 cluster_id: cluster_id.clone(),
                 cluster_created_by_adapter,
                 started_at_ms,
+                pg_io_baseline: None,
             },
         );
 
@@ -2156,6 +2248,24 @@ impl Handler for DatabricksAdapter {
                 eprintln!("[databricks-adapter] creating performance indexes on Lakebase...");
                 if let Err(e) = self.create_lakebase_pg_indexes(lakebase_config).await {
                     eprintln!("[databricks-adapter] index creation failed (non-fatal): {e}");
+                }
+
+                // Snapshot pg_stat_io counters now so we can subtract them later to
+                // report only the I/O that happened during this benchmark run.
+                eprintln!(
+                    "[databricks-adapter] snapshotting pg_stat_io baseline for disk I/O delta tracking..."
+                );
+                match self.snapshot_pg_io_baseline().await {
+                    Ok(baseline) => {
+                        if let Some(state) = self.runs.get_mut(&run_id) {
+                            state.pg_io_baseline = Some(baseline);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "[databricks-adapter] pg_stat_io baseline snapshot failed (non-fatal): {e}"
+                        );
+                    }
                 }
             }
         }
@@ -2397,6 +2507,25 @@ impl Handler for DatabricksAdapter {
                     resource,
                     ingestion,
                 })
+            }
+            ComputeTarget::Lakebase(cfg) => {
+                let baseline = self
+                    .runs
+                    .get(&run_id)
+                    .and_then(|s| s.pg_io_baseline.as_ref());
+                match self.collect_lakebase_metrics(cfg, baseline).await {
+                    Ok(m) => {
+                        eprintln!(
+                            "[databricks-adapter] Lakebase metrics: ingestion={:?}, resource={:?}",
+                            m.ingestion, m.resource
+                        );
+                        Ok(m)
+                    }
+                    Err(e) => {
+                        eprintln!("[databricks-adapter] Lakebase metrics collection failed: {e}");
+                        Ok(MetricsResponse::default())
+                    }
+                }
             }
             _ => Ok(MetricsResponse::default()),
         }

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -235,8 +235,7 @@ struct PgIoBaseline {
 
 #[derive(Debug, Clone)]
 struct RunState {
-    #[allow(dead_code)]
-    table_format: TableFormat,
+    _table_format: TableFormat,
     variant: DatabricksVariant,
     scenario_slug: String,
     created_tables: Vec<String>,
@@ -701,31 +700,6 @@ impl DatabricksAdapter {
         Ok(())
     }
 
-    #[allow(dead_code)]
-    async fn delete_uc_table_if_exists(&self, table_name: &str) -> Result<()> {
-        let full_name = self.uc_table_full_name(table_name);
-        let delete_url = format!(
-            "https://{}/api/2.1/unity-catalog/tables/{full_name}",
-            self.config.endpoint
-        );
-        let response = self
-            .client
-            .delete(delete_url)
-            .bearer_auth(&self.config.token)
-            .send()
-            .await?;
-
-        if response.status() == StatusCode::OK || response.status() == StatusCode::NOT_FOUND {
-            return Ok(());
-        }
-
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        Err(anyhow!(
-            "Databricks Unity Catalog tables/delete failed ({status}) for '{full_name}': {body}"
-        ))
-    }
-
     async fn execute_sql_statement(&self, statement: &str) -> Result<()> {
         let execute_url = format!("https://{}/api/2.0/sql/statements/", self.config.endpoint);
         let payload = json!({
@@ -887,46 +861,6 @@ impl DatabricksAdapter {
         }
     }
 
-    /// Execute a SQL query via the Statements API and return inline result rows.
-    #[allow(dead_code)]
-    async fn execute_sql_query(&self, statement: &str) -> Result<Vec<Vec<Option<String>>>> {
-        let execute_url = format!("https://{}/api/2.0/sql/statements/", self.config.endpoint);
-        let payload = json!({
-            "warehouse_id": self.config.warehouse_id,
-            "catalog": self.config.catalog,
-            "schema": self.config.schema,
-            "statement": statement,
-            "wait_timeout": "30s",
-        });
-
-        let response = self
-            .client
-            .post(execute_url)
-            .bearer_auth(&self.config.token)
-            .json(&payload)
-            .send()
-            .await?;
-
-        if response.status() != StatusCode::OK {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(anyhow!("SQL query failed ({status}): {body}"));
-        }
-
-        let body: StatementWithResultResponse = response.json().await?;
-        match body.status.state {
-            StatementState::Succeeded => Ok(body.result.map(|r| r.data_array).unwrap_or_default()),
-            StatementState::Failed => {
-                Err(anyhow!("SQL query failed: {}", body.status.error_message()))
-            }
-            StatementState::Canceled => Err(anyhow!("SQL query canceled")),
-            StatementState::Pending | StatementState::Running => Err(anyhow!(
-                "SQL query timed out (statement_id={})",
-                body.statement_id
-            )),
-        }
-    }
-
     /// Fire a tagged marker query and wait for it to appear in the Query History
     /// API.  Once the marker is visible, all earlier queries from this warehouse
     /// are also guaranteed to be visible.
@@ -1005,41 +939,6 @@ impl DatabricksAdapter {
     /// most workspace-scoped tokens lack.
     async fn sum_query_history_io(&self, start_time_ms: u64) -> Result<(u64, u64)> {
         self.sum_query_history_io_rest(start_time_ms).await
-    }
-
-    /// SQL path: query `system.query.history` for aggregated I/O bytes.
-    /// Currently unused — requires elevated permission `USE SCHEMA` on `system.query`.
-    #[allow(dead_code)]
-    async fn sum_query_history_io_sql(&self, start_time_ms: u64) -> Result<(u64, u64)> {
-        let query = format!(
-            "SELECT COALESCE(SUM(read_bytes), 0), COALESCE(SUM(write_remote_bytes), 0) \
-             FROM system.query.history \
-             WHERE warehouse_id = '{}' \
-               AND start_time >= TIMESTAMP_MILLIS({}) \
-               AND status = 'FINISHED'",
-            self.config.warehouse_id, start_time_ms
-        );
-
-        let rows = self.execute_sql_query(&query).await?;
-        let row = rows
-            .first()
-            .ok_or_else(|| anyhow!("No rows returned from system.query.history sum"))?;
-
-        let total_read = row
-            .first()
-            .and_then(|v| v.as_deref())
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(0);
-        let total_write = row
-            .get(1)
-            .and_then(|v| v.as_deref())
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or(0);
-
-        eprintln!(
-            "[databricks-adapter] query history totals (SQL): read_bytes={total_read} write_bytes={total_write}"
-        );
-        Ok((total_read, total_write))
     }
 
     /// REST path: paginate through `/api/2.0/sql/history/queries` and sum
@@ -1318,131 +1217,6 @@ impl DatabricksAdapter {
         Ok(None)
     }
 
-    #[allow(dead_code)]
-    fn uc_column_type_for_arrow(data_type: &DataType) -> Result<UcColumnType> {
-        match data_type {
-            DataType::Boolean => Ok(UcColumnType::new("BOOLEAN", "BOOLEAN", "\"boolean\"")),
-            DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::UInt8
-            | DataType::UInt16 => Ok(UcColumnType::new("INT", "INT", "\"integer\"")),
-            DataType::Int64 | DataType::UInt32 | DataType::UInt64 => {
-                Ok(UcColumnType::new("LONG", "BIGINT", "\"long\""))
-            }
-            DataType::Float32 => Ok(UcColumnType::new("FLOAT", "FLOAT", "\"float\"")),
-            DataType::Float64 => Ok(UcColumnType::new("DOUBLE", "DOUBLE", "\"double\"")),
-            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
-                Ok(UcColumnType::new("STRING", "STRING", "\"string\""))
-            }
-            DataType::Date32 => Ok(UcColumnType::new("DATE", "DATE", "\"date\"")),
-            DataType::Timestamp(_, _) => {
-                Ok(UcColumnType::new("TIMESTAMP", "TIMESTAMP", "\"timestamp\""))
-            }
-            DataType::Decimal128(precision, scale) => Ok(UcColumnType::new(
-                "DECIMAL",
-                format!("DECIMAL({precision}, {scale})"),
-                format!("\"decimal({precision},{scale})\""),
-            )),
-            other => Err(anyhow!(
-                "Unsupported Arrow data type for Unity Catalog table creation: {other:?}"
-            )),
-        }
-    }
-
-    #[allow(dead_code)]
-    async fn uc_table_exists(&self, table_name: &str) -> Result<bool> {
-        let full_name = self.uc_table_full_name(table_name);
-        let get_url = format!(
-            "https://{}/api/2.1/unity-catalog/tables/{full_name}",
-            self.config.endpoint
-        );
-
-        let response = self
-            .client
-            .get(get_url)
-            .bearer_auth(&self.config.token)
-            .send()
-            .await?;
-
-        if response.status() == StatusCode::OK {
-            return Ok(true);
-        }
-
-        if response.status() == StatusCode::NOT_FOUND {
-            return Ok(false);
-        }
-
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        Err(anyhow!(
-            "Databricks Unity Catalog tables/get failed ({status}) for '{full_name}': {body}"
-        ))
-    }
-
-    #[allow(dead_code)]
-    async fn create_uc_table_if_not_exists(
-        &self,
-        table_name: &str,
-        dataset_cfg: &DatasetConfig,
-    ) -> Result<bool> {
-        if self.uc_table_exists(table_name).await? {
-            return Ok(false);
-        }
-
-        let columns = dataset_cfg
-            .schema
-            .fields()
-            .iter()
-            .enumerate()
-            .map(|(position, field)| {
-                let col_type = Self::uc_column_type_for_arrow(field.data_type())?;
-                Ok::<_, anyhow::Error>(UcTableColumnCreateRequest {
-                    name: field.name().clone(),
-                    type_name: col_type.type_name,
-                    type_text: col_type.type_text,
-                    type_json: col_type.type_json,
-                    position,
-                    nullable: field.is_nullable(),
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let create_url = format!(
-            "https://{}/api/2.1/unity-catalog/tables",
-            self.config.endpoint
-        );
-        let response = self
-            .client
-            .post(create_url)
-            .bearer_auth(&self.config.token)
-            .json(&UcTableCreateRequest {
-                name: table_name.to_string(),
-                catalog_name: self.config.catalog.clone(),
-                schema_name: self.config.schema.clone(),
-                table_type: "MANAGED".to_string(),
-                data_source_format: "DELTA".to_string(),
-                columns,
-            })
-            .send()
-            .await?;
-
-        if response.status().is_success() {
-            return Ok(true);
-        }
-
-        if response.status() == StatusCode::CONFLICT {
-            return Ok(false);
-        }
-
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        Err(anyhow!(
-            "Databricks Unity Catalog tables/create failed ({status}) for '{}': {body}",
-            self.uc_table_full_name(table_name)
-        ))
-    }
-
     async fn lakebase_pg_uri(&self) -> Result<String> {
         let lakebase_config = match &self.config.compute_target {
             ComputeTarget::Lakebase(cfg) => cfg,
@@ -1691,26 +1465,7 @@ impl DatabricksAdapter {
         // rows_ingested / bytes_ingested: not available on Lakebase.
         // The synced table pipeline writes at the storage layer, bypassing PG's
         // tuple tracking (n_tup_ins) and relation size accounting
-        // (pg_total_relation_size), so both are always zero.
-        //
-        // let _schema = &lakebase_config.schema;
-        // let rows_ingested: Option<u64> = client
-        //     .query_one(
-        //         "SELECT COALESCE(SUM(n_tup_ins), 0)::bigint FROM pg_stat_user_tables WHERE schemaname = $1",
-        //         &[&schema],
-        //     )
-        //     .await
-        //     .ok()
-        //     .map(|row| row.get::<_, i64>(0) as u64);
-        //
-        // let bytes_ingested: Option<u64> = client
-        //     .query_one(
-        //         "SELECT COALESCE(SUM(pg_total_relation_size(schemaname || '.' || tablename)), 0)::bigint FROM pg_tables WHERE schemaname = $1",
-        //         &[&schema],
-        //     )
-        //     .await
-        //     .ok()
-        //     .map(|row| row.get::<_, i64>(0) as u64);
+        // (pg_total_relation_size), so both are always zero so we don't query them
 
         let mut resource = ResourceMetrics::default();
 
@@ -1957,72 +1712,10 @@ enum StatementState {
     Canceled,
 }
 
-/// Statement response that includes inline result data.
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct StatementWithResultResponse {
-    statement_id: String,
-    status: StatementStatus,
-    #[serde(default)]
-    result: Option<StatementResultData>,
-}
-
-#[derive(Debug, Deserialize)]
-#[allow(dead_code)]
-struct StatementResultData {
-    #[serde(default)]
-    data_array: Vec<Vec<Option<String>>>,
-}
-
 #[derive(Debug, Serialize)]
 struct UcSchemaCreateRequest {
     catalog_name: String,
     name: String,
-}
-
-#[derive(Debug)]
-#[allow(dead_code)]
-struct UcColumnType {
-    type_name: String,
-    type_text: String,
-    type_json: String,
-}
-
-#[allow(dead_code)]
-impl UcColumnType {
-    fn new(
-        type_name: impl Into<String>,
-        type_text: impl Into<String>,
-        type_json: impl Into<String>,
-    ) -> Self {
-        Self {
-            type_name: type_name.into(),
-            type_text: type_text.into(),
-            type_json: type_json.into(),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-#[allow(dead_code)]
-struct UcTableColumnCreateRequest {
-    name: String,
-    type_name: String,
-    type_text: String,
-    type_json: String,
-    position: usize,
-    nullable: bool,
-}
-
-#[derive(Debug, Serialize)]
-#[allow(dead_code)]
-struct UcTableCreateRequest {
-    name: String,
-    catalog_name: String,
-    schema_name: String,
-    table_type: String,
-    data_source_format: String,
-    columns: Vec<UcTableColumnCreateRequest>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2031,23 +1724,11 @@ struct WarehouseInfoResponse {
     num_active_sessions: Option<u64>,
     #[serde(default)]
     num_clusters: Option<u64>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    warehouse_type: Option<String>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    cluster_size: Option<String>,
 }
 
 /// A single query entry from the Query History API.
 #[derive(Debug, Deserialize)]
 struct QueryHistoryEntry {
-    #[serde(default)]
-    #[allow(dead_code)]
-    query_id: String,
-    #[serde(default)]
-    #[allow(dead_code)]
-    status: Option<String>,
     #[serde(default)]
     metrics: Option<QueryHistoryMetrics>,
 }
@@ -2152,7 +1833,7 @@ impl Handler for DatabricksAdapter {
         self.runs.insert(
             run_id,
             RunState {
-                table_format,
+                _table_format: table_format,
                 variant,
                 scenario_slug: scenario_slug.clone(),
                 created_tables: Vec::new(),

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -235,6 +235,7 @@ struct PgIoBaseline {
 
 #[derive(Debug, Clone)]
 struct RunState {
+    #[allow(dead_code)]
     table_format: TableFormat,
     variant: DatabricksVariant,
     scenario_slug: String,
@@ -700,6 +701,7 @@ impl DatabricksAdapter {
         Ok(())
     }
 
+    #[allow(dead_code)]
     async fn delete_uc_table_if_exists(&self, table_name: &str) -> Result<()> {
         let full_name = self.uc_table_full_name(table_name);
         let delete_url = format!(
@@ -886,6 +888,7 @@ impl DatabricksAdapter {
     }
 
     /// Execute a SQL query via the Statements API and return inline result rows.
+    #[allow(dead_code)]
     async fn execute_sql_query(&self, statement: &str) -> Result<Vec<Vec<Option<String>>>> {
         let execute_url = format!("https://{}/api/2.0/sql/statements/", self.config.endpoint);
         let payload = json!({
@@ -1006,6 +1009,7 @@ impl DatabricksAdapter {
 
     /// SQL path: query `system.query.history` for aggregated I/O bytes.
     /// Currently unused — requires elevated permission `USE SCHEMA` on `system.query`.
+    #[allow(dead_code)]
     async fn sum_query_history_io_sql(&self, start_time_ms: u64) -> Result<(u64, u64)> {
         let query = format!(
             "SELECT COALESCE(SUM(read_bytes), 0), COALESCE(SUM(write_remote_bytes), 0) \
@@ -1314,6 +1318,7 @@ impl DatabricksAdapter {
         Ok(None)
     }
 
+    #[allow(dead_code)]
     fn uc_column_type_for_arrow(data_type: &DataType) -> Result<UcColumnType> {
         match data_type {
             DataType::Boolean => Ok(UcColumnType::new("BOOLEAN", "BOOLEAN", "\"boolean\"")),
@@ -1345,6 +1350,7 @@ impl DatabricksAdapter {
         }
     }
 
+    #[allow(dead_code)]
     async fn uc_table_exists(&self, table_name: &str) -> Result<bool> {
         let full_name = self.uc_table_full_name(table_name);
         let get_url = format!(
@@ -1374,6 +1380,7 @@ impl DatabricksAdapter {
         ))
     }
 
+    #[allow(dead_code)]
     async fn create_uc_table_if_not_exists(
         &self,
         table_name: &str,
@@ -1954,6 +1961,7 @@ enum StatementState {
 
 /// Statement response that includes inline result data.
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct StatementWithResultResponse {
     statement_id: String,
     status: StatementStatus,
@@ -1962,6 +1970,7 @@ struct StatementWithResultResponse {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct StatementResultData {
     #[serde(default)]
     data_array: Vec<Vec<Option<String>>>,
@@ -1974,12 +1983,14 @@ struct UcSchemaCreateRequest {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct UcColumnType {
     type_name: String,
     type_text: String,
     type_json: String,
 }
 
+#[allow(dead_code)]
 impl UcColumnType {
     fn new(
         type_name: impl Into<String>,
@@ -1995,6 +2006,7 @@ impl UcColumnType {
 }
 
 #[derive(Debug, Serialize)]
+#[allow(dead_code)]
 struct UcTableColumnCreateRequest {
     name: String,
     type_name: String,
@@ -2005,6 +2017,7 @@ struct UcTableColumnCreateRequest {
 }
 
 #[derive(Debug, Serialize)]
+#[allow(dead_code)]
 struct UcTableCreateRequest {
     name: String,
     catalog_name: String,
@@ -2021,8 +2034,10 @@ struct WarehouseInfoResponse {
     #[serde(default)]
     num_clusters: Option<u64>,
     #[serde(default)]
+    #[allow(dead_code)]
     warehouse_type: Option<String>,
     #[serde(default)]
+    #[allow(dead_code)]
     cluster_size: Option<String>,
 }
 
@@ -2030,8 +2045,10 @@ struct WarehouseInfoResponse {
 #[derive(Debug, Deserialize)]
 struct QueryHistoryEntry {
     #[serde(default)]
+    #[allow(dead_code)]
     query_id: String,
     #[serde(default)]
+    #[allow(dead_code)]
     status: Option<String>,
     #[serde(default)]
     metrics: Option<QueryHistoryMetrics>,


### PR DESCRIPTION
## 🗣 Description

PR adds Lakebase PG metrics collection (disk I/O, connections). It connects directly to the Lakebase PostgreSQL interface to collect per-run metrics as those metrics are not available through the Databricks SQL Statement API:
- **`disk_read_bytes` / `disk_write_bytes`** – delta from `pg_stat_io` (baseline snapshotted after setup, subtracted at each scrape)
- **`active_connections`** – count from `pg_stat_activity`
- ~~**`rows_ingested`** – `SUM(n_tup_ins)` from `pg_stat_user_tables`~~ — always 0; the synced table pipeline bypasses PG tuple tracking
- ~~**`bytes_ingested`** – `SUM(pg_total_relation_size)` across benchmark tables~~ — always 0; the synced table pipeline bypasses PG relation size accounting

>[databricks-adapter] Lakebase metrics: ingestion=IngestionMetrics { rows_ingested: None, bytes_ingested: None, rows_per_sec: None, **active_connections: Some(6)** }, resource=ResourceMetrics { cpu_usage_percent: None, memory_usage_bytes: None, **disk_read_bytes: Some(573440)**, **disk_write_bytes: Some(1089536)**, disk_read_iops: None, disk_write_iops: None, num_compute_nodes: None }

### Implementation details
- `pg_stat_reset()` requires superuser and is denied on Lakebase, so `pg_stat_io` counters are snapshotted at the end of setup and subtracted at each metrics scrape to isolate per-run I/O.
- Metrics unavailable on Lakebase (`cpu_usage`, `memory_usage`, `disk_iops`, `rows_ingested`, `bytes_ingested`) are omitted.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
