### PR TITLE
Refactor ADBC driver installation to use setup-dbc action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -142,10 +142,9 @@ jobs:
             --region us-east-1
 
       - name: Install ADBC driver
-        run: |
-          curl -LsSf https://dbc.columnar.tech/install.sh | sh
-          source "$HOME/.local/bin/env"
-          dbc install flightsql
+        uses: columnar-tech/setup-dbc@v1
+        with:
+          drivers: flightsql
 
       - name: Run spicebench
         if: ${{ false }}

--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -216,19 +216,15 @@ jobs:
 
       - name: Install ADBC Postgres driver
         if: ${{ startsWith(github.event.inputs.system_under_test || 'spice_cloud', 'databricks-') }}
-        run: |
-          set -euo pipefail
-          curl -LsSf https://dbc.columnar.tech/install.sh | sh
-          source "$HOME/.local/bin/env"
-          dbc install postgresql
+        uses: columnar-tech/setup-dbc@v1
+        with:
+          drivers: postgresql
 
       - name: Install ADBC FlightSQL driver
         if: ${{ !startsWith(github.event.inputs.system_under_test || 'spice_cloud', 'databricks-') }}
-        run: |
-          set -euo pipefail
-          curl -LsSf https://dbc.columnar.tech/install.sh | sh
-          source "$HOME/.local/bin/env"
-          dbc install flightsql
+        uses: columnar-tech/setup-dbc@v1
+        with:
+          drivers: flightsql
 
       - name: Run spicebench
         env:


### PR DESCRIPTION
This pull request updates the workflow configuration for installing ADBC drivers in GitHub Actions. The main change is replacing manual installation script steps with the official `columnar-tech/setup-dbc` action, which simplifies setup and improves maintainability.

Workflow improvements:

* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L145-R147): Replaced manual installation steps for the ADBC FlightSQL driver with the `columnar-tech/setup-dbc` action, specifying the `flightsql` driver.
* [`.github/workflows/run_spicebench.yml`](diffhunk://#diff-27719c0f45ab98eed387fca978ae34b81a70942d1268ab8c32fa79e5ba53c2e2L219-R227): Replaced manual installation steps for the ADBC Postgres and FlightSQL drivers with the `columnar-tech/setup-dbc` action, specifying the appropriate driver for each workflow condition.