### PR TITLE
Switch adbc-databricks driver to `spicebench` branch (schema error fix)

### DIFF
--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -201,7 +201,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: spiceai/adbc-databricks
-          ref: viktor/improve-databricks-bulk-insert
+          ref: spicebench
           path: adbc-databricks
 
       - name: Build databricks Go ADBC driver


### PR DESCRIPTION
## 🗣 Description

Updates the CI workflow to checkout the `spicebench` branch of `adbc-databricks` driver, which includes a fix for empty `SchemaBytes` on 0-row query results:
- https://github.com/spiceai/adbc-databricks/commit/e038ca674da20292e172ac1f57d6869460411458


## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
