### PR TITLE
Add executor_replicas input and env to workflow

### DIFF
--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -45,6 +45,16 @@ on:
         required: false
         default: false
         type: boolean
+      executor_replicas:
+        description: 'Number of executor replicas for the Spice Cloud app (maps to SPIDAPTER_EXECUTOR_REPLICAS)'
+        required: false
+        default: '1'
+        type: string
+      disable_teardown:
+        description: 'Skip the teardown RPC call to the system adapter after the benchmark completes (useful for inspecting spice_cloud state after a run)'
+        required: false
+        default: false
+        type: boolean
 jobs:
   run-spicebench:
     name: Run spicebench
@@ -231,6 +241,7 @@ jobs:
           VALIDATE_CHECKPOINT_RESULTS: 'true'
           ENABLE_MODULE_DEBUG_LOGGING: ${{ github.event.inputs.enable_module_debug_logging || 'false' }}
           SCRAPE_SUT_METRICS: 'true'
+          SPIDAPTER_EXECUTOR_REPLICAS: ${{ github.event.inputs.executor_replicas || '1' }}
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}
@@ -244,6 +255,7 @@ jobs:
           LAKEBASE_DATABASE_INSTANCE: ${{ secrets.LAKEBASE_DATABASE_INSTANCE }}
           SPIDAPTER_ICEBERG_REGION: us-west-1
           SPIDAPTER_ICEBERG_CATALOG_FROM: iceberg:https://glue.us-west-1.amazonaws.com/iceberg/v1/catalogs/211125479522/namespaces
+          DISABLE_TEARDOWN: ${{ github.event.inputs.disable_teardown || 'false' }}
         run: |
           set -euo pipefail
           if [ "${ENABLE_MODULE_DEBUG_LOGGING}" = "true" ]; then
@@ -310,7 +322,7 @@ jobs:
             export SPICEBENCH_ADBC_UPDATE_STRATEGY=bulk_ingest_upsert
             export SPICEBENCH_ADBC_DELETE_BATCH_SIZE=50000
             ADAPTER_CMD="docker"
-            ADAPTER_ARGS="run -i -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL -e AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY} -e SPIDAPTER_ICEBERG_REGION -e SPIDAPTER_ICEBERG_CATALOG_FROM -e SCHEDULER_STATE_LOCATION ghcr.io/spiceai/spidapter:${{ github.event.inputs.spidapter_version || 'latest' }} stdio --verbose --channel nightly"
+            ADAPTER_ARGS="run -i -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL -e AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY} -e SPIDAPTER_ICEBERG_REGION -e SPIDAPTER_ICEBERG_CATALOG_FROM -e SPIDAPTER_EXECUTOR_REPLICAS=${SPIDAPTER_EXECUTOR_REPLICAS} -e SCHEDULER_STATE_LOCATION ghcr.io/spiceai/spidapter:${{ github.event.inputs.spidapter_version || 'latest' }} stdio --verbose --channel nightly"
             ADAPTER_ENVS=""
           fi
 
@@ -321,6 +333,11 @@ jobs:
             ADAPTER_ENVS="${ADAPTER_ENVS} --system-adapter-env LAKEBASE_PG_DB_NAME=${LAKEBASE_PG_DB_NAME}"
             ADAPTER_ENVS="${ADAPTER_ENVS} --system-adapter-env LAKEBASE_PG_SCHEMA=${LAKEBASE_PG_SCHEMA}"
             ADAPTER_ENVS="${ADAPTER_ENVS} --system-adapter-env LAKEBASE_DATABASE_INSTANCE=${LAKEBASE_DATABASE_INSTANCE}"
+          fi
+
+          NO_TEARDOWN_ARG=""
+          if [ "${DISABLE_TEARDOWN}" = "true" ]; then
+            NO_TEARDOWN_ARG="--no-teardown"
           fi
 
           ~/.spice/bin/spicebench run \
@@ -335,3 +352,4 @@ jobs:
             --system-adapter-stdio-args "${ADAPTER_ARGS}" \
             ${ADAPTER_ENVS} \
             ${SCHEDULER_STATE_ADAPTER_ENV} \
+            ${NO_TEARDOWN_ARG}

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -181,6 +181,13 @@ pub struct RunArgs {
     /// when individual query latency is high.
     #[arg(long, default_value_t = 5)]
     pub(crate) checkpoint_validation_period: u64,
+
+    /// Skip the teardown RPC call to the system adapter after the benchmark completes.
+    ///
+    /// Useful when you want to inspect the system state after a run without
+    /// triggering adapter-side cleanup (e.g. for debugging spice_cloud deployments).
+    #[arg(long, default_value_t = false)]
+    pub(crate) no_teardown: bool,
 }
 
 fn parse_key_val(s: &str) -> Result<(String, String), String> {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -390,8 +390,11 @@ pub async fn execute(args: &RunArgs) -> anyhow::Result<()> {
     )
     .await;
 
-    // After successful setup, always teardown even if there are errors in between.
-    if let Err(e) = system_adapter_client.lock().await.teardown(run_id).await {
+    // After successful setup, always teardown even if there are errors in between,
+    // unless --no-teardown was requested (e.g. to inspect cloud state after a run).
+    if args.no_teardown {
+        tracing::info!("Skipping teardown (--no-teardown flag is set).");
+    } else if let Err(e) = system_adapter_client.lock().await.teardown(run_id).await {
         tracing::error!("Failed to teardown system adapter: {e}");
     }
 


### PR DESCRIPTION
This pull request adds new configuration options and improves flexibility for running the `spicebench` workflow, especially around system teardown and executor scaling. The changes introduce new workflow inputs, environment variables, and command-line arguments to allow for more control over the benchmarking process, particularly for debugging and scaling scenarios.

**Workflow configuration improvements:**

* Added new workflow inputs to `.github/workflows/run_spicebench.yml` for `scheduler_state_location`, `executor_replicas`, and `disable_teardown`, allowing users to configure the scheduler state location, number of executor replicas, and whether to skip teardown after a run.
* Passed the new inputs as environment variables (`SPIDAPTER_EXECUTOR_REPLICAS`, `DISABLE_TEARDOWN`) to the workflow jobs, and updated the Docker command to use the executor replicas value. [[1]](diffhunk://#diff-27719c0f45ab98eed387fca978ae34b81a70942d1268ab8c32fa79e5ba53c2e2R262) [[2]](diffhunk://#diff-27719c0f45ab98eed387fca978ae34b81a70942d1268ab8c32fa79e5ba53c2e2R276) [[3]](diffhunk://#diff-27719c0f45ab98eed387fca978ae34b81a70942d1268ab8c32fa79e5ba53c2e2L325-R342)

**Teardown control enhancements:**

* Updated the workflow script to add a `--no-teardown` argument to the `spicebench run` command if teardown is disabled, enabling users to inspect the system state after a run for debugging purposes. [[1]](diffhunk://#diff-27719c0f45ab98eed387fca978ae34b81a70942d1268ab8c32fa79e5ba53c2e2R355-R359) [[2]](diffhunk://#diff-27719c0f45ab98eed387fca978ae34b81a70942d1268ab8c32fa79e5ba53c2e2R372)
* Added a new `no_teardown` argument to the `RunArgs` struct in `src/args/mod.rs`, and updated the `run` command in `src/commands/run.rs` to respect this flag, skipping the teardown step if requested and logging the action. [[1]](diffhunk://#diff-c5354523dab7ee14c84278715c952cb7e302af46f5c8372b94375b36f003b93eR184-R190) [[2]](diffhunk://#diff-2218893006e42ddf80cedd8282a70b44af7fbb2b1423527dfcb1666a895ed211L389-R393)