### PR TITLE
Fix missing `catalog_namespace` for Lakebase in setup response

### DIFF
--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -1986,7 +1986,7 @@ impl Handler for DatabricksAdapter {
                             Value::String(self.config.staging_volume_path.clone()),
                         ),
                     ]),
-                    catalog_namespace: None,
+                    catalog_namespace: Some(format!("{}.{}", self.config.catalog, self.config.schema)),
                     read_driver: Some((
                         AdbcDriver::Postgresql,
                         HashMap::from([("uri".to_string(), Value::String(pg_uri))]),


### PR DESCRIPTION
## 🗣 Description

Lakebase setup was returning `catalog_namespace: None`, causing ADBC bulk ingest to run without a target catalog/schema. This led to staging upload failures (HTTP 408) because the volume path couldn't be resolved.

The fix sets `catalog_namespace` to `catalog.schema` for Lakebase, matching the non-Lakebase path. Ingest for both variants uses the Databricks ADBC driver and needs the same namespace.


## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
