### PR TITLE
Run final checkpoint validation when ETL pipeline completes

### DIFF
--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -833,7 +833,71 @@ pub(crate) async fn run(
                     }
                     PipelineState::Stopped(StopReason::Completed) => {
                         println!("ETL pipeline completed");
-                        if !has_checkpoint_validation {
+
+                        // --- Final checkpoint validation ---
+                        // The pipeline transitions directly from Running →
+                        // Completed after the last batch, so the final
+                        // checkpoint boundary is never seen as a Paused state.
+                        // Run validation for it here.
+                        if has_checkpoint_validation
+                            && let Some(cp_dir) = checkpoint_dir
+                        {
+                            let checkpoint_idx = etl_pipeline.checkpoint_idx();
+                            match load_checkpoint_results(cp_dir, checkpoint_idx, &query_names) {
+                                Ok(expected_results) if !expected_results.is_empty() => {
+                                    tracing::info!(
+                                        checkpoint_idx,
+                                        num_queries = expected_results.len(),
+                                        "Running final checkpoint validation"
+                                    );
+
+                                    let checkpoint_pause_time = std::time::Instant::now();
+
+                                    let result = run_checkpoint_validation(
+                                        &validation_executor,
+                                        &queries,
+                                        &expected_results,
+                                        checkpoint_idx,
+                                        common_args.concurrency,
+                                        Duration::from_secs(common_args.checkpoint_validation_period),
+                                        Duration::from_secs(600),
+                                        checkpoint_pause_time,
+                                    )
+                                    .await;
+
+                                    match result {
+                                        CheckpointValidationResult::Converged { e2e_latency_ms } => {
+                                            checkpoint_e2e_latency_samples.push(e2e_latency_ms);
+                                        }
+                                        CheckpointValidationResult::Interrupted => {
+                                            eprintln!("Interrupt received during final checkpoint validation, stopping...");
+                                            shutdown_token.cancel();
+                                            break Some(RunOutcome::Cancelled);
+                                        }
+                                        CheckpointValidationResult::TimedOut => {
+                                            eprintln!(
+                                                "Final checkpoint {checkpoint_idx} validation timed out after 600s without convergence, aborting run"
+                                            );
+                                            shutdown_token.cancel();
+                                            break Some(RunOutcome::ValidationTimeout);
+                                        }
+                                    }
+                                }
+                                Ok(_) => {
+                                    tracing::info!(
+                                        checkpoint_idx,
+                                        "No final checkpoint results found, skipping validation"
+                                    );
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        checkpoint_idx,
+                                        error = %e,
+                                        "Failed to load final checkpoint results, skipping validation"
+                                    );
+                                }
+                            }
+                        } else if !has_checkpoint_validation {
                             // When results validation is not enabled, wait for
                             // at least 1 query set iteration to complete so we
                             // collect meaningful query metrics before stopping.
@@ -856,6 +920,7 @@ pub(crate) async fn run(
                                 tokio::time::sleep(POLL_INTERVAL).await;
                             }
                         }
+
                         println!("Stopping benchmark...");
                         shutdown_token.cancel();
                         break None;


### PR DESCRIPTION
## Problem

When the ETL pipeline finishes its last batch, it transitions directly from `Running` → `Completed`, bypassing the `Paused` state where checkpoint validation normally runs. This means the final checkpoint (representing all data loaded) is never validated.

In the [latest CI run](https://github.com/spiceai/spicebench/actions/runs/23128272159/job/67175880371), the manifest has 2 checkpoints (indexes 0 and 1) with `checkpoint_interval_steps=3`. Checkpoint 0 was validated during the `Paused` boundary, but checkpoint 1 was skipped:

```
ETL pipeline paused at checkpoint boundary checkpoint_idx=0
Running checkpoint validation checkpoint_idx=0 num_queries=21
Checkpoint 0 converged: E2E latency = 0.0s
...
ETL pipeline completed        ← checkpoint 1 never validated
Stopping benchmark...
```

## Fix

Add final checkpoint validation in the `Completed` handler. When `has_checkpoint_validation` is true, load and validate the final checkpoint results (using `etl_pipeline.checkpoint_idx()`) before stopping the benchmark. The existing "wait for 1 query set iteration" fallback is preserved for runs without checkpoint validation.