### PR TITLE
databricks: include `spill_to_disk_bytes` in `disk_write_bytes` metric

### DIFF
--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -928,8 +928,8 @@ impl DatabricksAdapter {
         }
     }
 
-    /// Sum `read_bytes` + `write_remote_bytes` from query history for all
-    /// FINISHED queries on this warehouse since `start_time_ms`.
+    /// Sum `read_bytes` and `write_remote_bytes + spill_to_disk_bytes` from query
+    /// history for all FINISHED queries on this warehouse since `start_time_ms`.
     ///
     /// Uses the REST Query History API (`/api/2.0/sql/history/queries`).
     ///
@@ -942,7 +942,7 @@ impl DatabricksAdapter {
     }
 
     /// REST path: paginate through `/api/2.0/sql/history/queries` and sum
-    /// per-query `metrics.read_bytes` and `metrics.write_remote_bytes`.
+    /// per-query `metrics.read_bytes` and `metrics.write_remote_bytes + spill_to_disk_bytes`.
     async fn sum_query_history_io_rest(&self, start_time_ms: u64) -> Result<(u64, u64)> {
         let history_url = format!(
             "https://{}/api/2.0/sql/history/queries",
@@ -989,7 +989,8 @@ impl DatabricksAdapter {
             for entry in &body.res {
                 if let Some(ref m) = entry.metrics {
                     total_read += m.read_bytes.unwrap_or(0);
-                    total_write += m.write_remote_bytes.unwrap_or(0);
+                    total_write +=
+                        m.write_remote_bytes.unwrap_or(0) + m.spill_to_disk_bytes.unwrap_or(0);
                 }
             }
 
@@ -1796,11 +1797,14 @@ struct QueryHistoryMetrics {
     /// and local SSD/disk cache (`read_cache_bytes`). Maps to `disk_read_bytes`.
     #[serde(default)]
     read_bytes: Option<u64>,
-    /// Bytes written to remote cloud storage (S3/ADLS/GCS). This is the only write metric
-    /// available in the REST API — non-zero for DDL/DML that materializes data (e.g. CTAS).
-    /// Maps to `disk_write_bytes`.
+    /// Bytes written to remote cloud storage (S3/ADLS/GCS). Non-zero for DDL/DML that
+    /// materializes data (e.g. CTAS). Summed with `spill_to_disk_bytes` for `disk_write_bytes`.
     #[serde(default)]
     write_remote_bytes: Option<u64>,
+    /// Bytes temporarily written to local disk when query execution exceeds available memory.
+    /// Summed with `write_remote_bytes` for `disk_write_bytes`.
+    #[serde(default)]
+    spill_to_disk_bytes: Option<u64>,
 }
 
 /// Response from GET /api/2.0/sql/history/queries
@@ -2238,13 +2242,14 @@ impl Handler for DatabricksAdapter {
                     }
                 }
 
-                // Sum read_bytes and write_bytes from all queries since the run started.
-                // On periodic scrapes this is best-effort (Query History has ~5 min lag).
-                // On final scrape the marker wait above ensures completeness.
+                // Sum read_bytes and (write_remote_bytes + spill_to_disk_bytes) from all
+                // queries since the run started. On periodic scrapes this is best-effort
+                // (Query History has ~5 min lag). On final scrape the marker wait above
+                // ensures completeness.
                 match self.sum_query_history_io(started_at_ms).await {
                     Ok((total_read, total_write)) => {
                         eprintln!(
-                            "[databricks-adapter] query history totals: read_bytes={total_read} write_remote_bytes={total_write}"
+                            "[databricks-adapter] query history totals: read_bytes={total_read} write_bytes={total_write} (write_remote_bytes+spill_to_disk_bytes)"
                         );
                         resource.disk_read_bytes = Some(total_read);
                         resource.disk_write_bytes = Some(total_write);

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -949,8 +949,11 @@ impl DatabricksAdapter {
             self.config.endpoint
         );
 
-        let mut total_read: u64 = 0;
-        let mut total_write: u64 = 0;
+        let mut total_read_bytes: u64 = 0;
+        let mut total_read_remote_bytes: u64 = 0;
+        let mut total_read_cache_bytes: u64 = 0;
+        let mut total_write_remote_bytes: u64 = 0;
+        let mut total_spill_to_disk_bytes: u64 = 0;
         let mut page_token: Option<String> = None;
 
         loop {
@@ -988,9 +991,11 @@ impl DatabricksAdapter {
 
             for entry in &body.res {
                 if let Some(ref m) = entry.metrics {
-                    total_read += m.read_bytes.unwrap_or(0);
-                    total_write +=
-                        m.write_remote_bytes.unwrap_or(0) + m.spill_to_disk_bytes.unwrap_or(0);
+                    total_read_bytes += m.read_bytes.unwrap_or(0);
+                    total_read_remote_bytes += m.read_remote_bytes.unwrap_or(0);
+                    total_read_cache_bytes += m.read_cache_bytes.unwrap_or(0);
+                    total_write_remote_bytes += m.write_remote_bytes.unwrap_or(0);
+                    total_spill_to_disk_bytes += m.spill_to_disk_bytes.unwrap_or(0);
                 }
             }
 
@@ -1001,7 +1006,15 @@ impl DatabricksAdapter {
             }
         }
 
-        Ok((total_read, total_write))
+        let total_write_bytes = total_write_remote_bytes + total_spill_to_disk_bytes;
+
+        eprintln!(
+            "[databricks-adapter] query history I/O breakdown: \
+             total_read_bytes={total_read_bytes} (total_read_remote_bytes={total_read_remote_bytes}, total_read_cache_bytes={total_read_cache_bytes}), \
+             total_write_bytes={total_write_bytes} (total_write_remote_bytes={total_write_remote_bytes}, total_spill_to_disk_bytes={total_spill_to_disk_bytes})"
+        );
+
+        Ok((total_read_bytes, total_write_bytes))
     }
 
     async fn ensure_cluster_ready(&self) -> Result<(String, bool)> {
@@ -1797,6 +1810,12 @@ struct QueryHistoryMetrics {
     /// and local SSD/disk cache (`read_cache_bytes`). Maps to `disk_read_bytes`.
     #[serde(default)]
     read_bytes: Option<u64>,
+    /// Bytes read from remote cloud storage (S3/ADLS/GCS).
+    #[serde(default)]
+    read_remote_bytes: Option<u64>,
+    /// Bytes read from the local SSD/disk cache.
+    #[serde(default)]
+    read_cache_bytes: Option<u64>,
     /// Bytes written to remote cloud storage (S3/ADLS/GCS). Non-zero for DDL/DML that
     /// materializes data (e.g. CTAS). Summed with `spill_to_disk_bytes` for `disk_write_bytes`.
     #[serde(default)]
@@ -1929,11 +1948,10 @@ impl Handler for DatabricksAdapter {
         // Create managed UC tables (sources for synced tables) via SQL Warehouse.
         // Drop any stale tables from a previous failed run first to ensure idempotent setup.
         for (table_name, dataset_cfg) in &datasets {
-            let drop_sql = format!(
-                "DROP TABLE IF EXISTS {}",
-                self.table_full_name(table_name)
+            let drop_sql = format!("DROP TABLE IF EXISTS {}", self.table_full_name(table_name));
+            eprintln!(
+                "[databricks-adapter] dropping stale managed table (if exists) '{table_name}': {drop_sql}"
             );
-            eprintln!("[databricks-adapter] dropping stale managed table (if exists) '{table_name}': {drop_sql}");
             self.execute_sql_statement(&drop_sql)
                 .await
                 .map_err(|e| format!("Failed to drop stale managed table '{table_name}': {e}"))?;
@@ -2268,7 +2286,7 @@ impl Handler for DatabricksAdapter {
                 match self.sum_query_history_io(started_at_ms).await {
                     Ok((total_read, total_write)) => {
                         eprintln!(
-                            "[databricks-adapter] query history totals: read_bytes={total_read} write_bytes={total_write} (write_remote_bytes+spill_to_disk_bytes)"
+                            "[databricks-adapter] query history totals: read_bytes={total_read} write_bytes={total_write}"
                         );
                         resource.disk_read_bytes = Some(total_read);
                         resource.disk_write_bytes = Some(total_write);


### PR DESCRIPTION
Include `spill_to_disk_bytes` in the Databricks adapter's `disk_write_bytes` calculation to capture local disk pressure during query execution.

`disk_write_bytes` is now `SUM(write_remote_bytes + spill_to_disk_bytes)` per query, matching the symmetry of `disk_read_bytes = SUM(read_bytes)` which already combines remote and local reads.

**Before:**
- `disk_read_bytes` = `SUM(read_bytes)` — includes remote storage reads (`read_remote_bytes`) + local SSD cache reads (`read_cache_bytes`)
- `disk_write_bytes` = `SUM(write_remote_bytes)` — remote storage writes only

**After:**
- `disk_read_bytes` = `SUM(read_bytes)` — unchanged
- `disk_write_bytes` = `SUM(write_remote_bytes + spill_to_disk_bytes)` — remote storage writes + local disk spill

Both metrics now consistently aggregate across all storage tiers (remote cloud storage + local disk).

### Alternative: local-disk-only metrics

An alternative mapping approach considered was only node-local disk I/O (excluding remote cloud storage):
- `disk_read_bytes` = `read_cache_bytes` (local SSD cache hits)
- `disk_write_bytes` = `spill_to_disk_bytes` (local disk spill)

This would isolate physical node disk activity only, which is useful for identifying cache efficiency and memory pressure independently. The current approach (remote + local combined) was kept because remote cloud storage I/O is the Databricks equivalent of traditional disk I/O, and total I/O across storage tiers is more meaningful for benchmarking.

### Example for SF1 TPC-H on SQL Warehouse

>[databricks-adapter] query history I/O breakdown: total_read_bytes=20926123858 (total_read_remote_bytes=892476146, total_read_cache_bytes=20033647712), total_write_bytes=242795542 (total_write_remote_bytes=242795542, total_spill_to_disk_bytes=0)

| Metric | Value | Meaning |
|---|---|---|
| `total_read_bytes` | ~20.9 GB | Total I/O across all storage tiers |
| `total_read_remote_bytes` | ~892 MB (4.3%) | Cold reads from cloud object storage |
| `total_read_cache_bytes` | ~20.0 GB (95.7%) | Warm reads served from local SSD cache |
| `total_write_remote_bytes` | ~243 MB | SQL Warehouse DDL/DML writes only (ADBC bulk ingest not included; bypass the SQL Warehouse query engine |
| `total_spill_to_disk_bytes` | 0 | No memory pressure — queries fit in memory |

**Notes:**
- `spill_to_disk_bytes` = 0 is expected for moderate workloads with sufficient executor memory. Non-zero values indicate queries whose intermediate results (sorts, joins, aggregations) exceeded available memory.
- Databricks transparently populates local NVMe SSD cache on first remote read. Cache population writes are not tracked in Query History metrics so we see large total_read_cache_bytes, but this is NOT reflected in writes :(
- ADBC bulk ingest writes bypass the SQL Warehouse query engine and are not captured in `write_remote_bytes`. Only SQL-executed DDL/DML is tracked.

### Databricks query metrics reference

| Metric | Description |
|---|---|
| `read_bytes` | Total bytes read (remote + cache: read_remote_bytes + read_cache_bytes) |
| `read_remote_bytes` | Bytes fetched from cloud object storage |
| `read_cache_bytes` | Bytes served from local SSD cache |
| `write_remote_bytes` | Bytes written to cloud object storage |
| `spill_to_disk_bytes` | Bytes temporarily written to local disk during execution |
| `read_files_count` | Number of data files read |
| `write_remote_rows` | Rows written to cloud storage |
| `write_remote_files` | Files written to cloud storage |
| `network_sent_bytes` | Bytes sent to the client |
| `rows_read_count` | Total rows scanned |
| `pruned_bytes` | Bytes skipped via pruning |
| `task_total_time_ms` | Cumulative task execution time |
| `photon_total_time_ms` | Time in Photon engine |
