### PR TITLE
Update default data generation workflow parameters to match production datasets

### DIFF
--- a/.github/workflows/data_generation_run.yml
+++ b/.github/workflows/data_generation_run.yml
@@ -77,12 +77,12 @@ on:
       num_steps:
         description: 'Number of data generation steps (partitions for TPC-H dbgen)'
         required: false
-        default: '5'
+        default: '20'
         type: string
       checkpoint_interval_steps:
         description: 'Every N steps to take a checkpoint'
         required: false
-        default: '3'
+        default: '10'
         type: string
       update_ratio:
         description: 'Ratio of rows to update per step (0.0 to 1.0)'


### PR DESCRIPTION
Updates the `workflow_dispatch` defaults in `data_generation_run.yml`:

- **`num_steps`**: `5` → `20`
- **`checkpoint_interval_steps`**: `3` → `10`

These now match the parameters used for all four production datasets (sf0.01, sf0.1, sf1.0, sf10.0) on MinIO, preventing accidental undergeneration when triggering runs manually with defaults.