### PR TITLE
Simplify run_spicebench.yml workflow parameters

### DIFF
--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -18,45 +18,27 @@ on:
           - spice_cloud
           - databricks-sql
           - databricks-lakebase
-      etl_bucket:
-        description: 'S3 bucket for ETL source and target data'
+      etl_type:
+        description: 'ETL type'
         required: true
-        default: 'spicebench'
-        type: string
-      etl_prefix:
-        description: 'S3 key prefix (the {prefix} portion of {prefix}/{scenario}/{version}/)'
-        required: false
-        default: 'data-gen'
-        type: string
+        default: 'append-only'
+        type: choice
+        options:
+          - append-only
+          - mutations
       scale_factor:
-        description: 'TPC-H scale factor used to derive the ETL version path segment automatically'
+        description: 'Scale Factor'
         required: true
-        type: string
-        default: '1.0'
-      etl_region:
-        description: 'AWS region for the ETL S3 bucket'
-        required: false
-        default: 'us-east-1'
-        type: string
-      num_query_clients:
-        description: 'Number of query clients to run (maps to spicebench --concurrency)'
-        required: false
-        default: '8'
-        type: string
-      validate_checkpoint_results:
-        description: 'Enable checkpoint-based result validation (maps to spicebench --validate-results)'
-        required: false
-        default: true
-        type: boolean
+        default: '1'
+        type: choice
+        options:
+          - '0.1'
+          - '1'
+          - '10'
       enable_module_debug_logging:
-        description: 'Enable debug logs only for SpiceBench modules (etl, spicebench, data_generation)'
+        description: 'Enable debug logs'
         required: false
         default: false
-        type: boolean
-      scrape_sut_metrics:
-        description: 'Enable periodic SUT metrics collection via the system adapter (maps to spicebench --scrape-sut-metrics)'
-        required: false
-        default: true
         type: boolean
 jobs:
   run-spicebench:
@@ -234,16 +216,16 @@ jobs:
           SCENARIO: ${{ github.event.inputs.scenario || 'tpch' }}
           SYSTEM_UNDER_TEST: ${{ github.event.inputs.system_under_test || 'spice_cloud' }}
           SYSTEM_ADAPTER: ${{ github.event.inputs.system_under_test || 'spice_cloud' }}
-          NUM_QUERY_CLIENTS: ${{ github.event.inputs.num_query_clients || '8' }}
-          ETL_BUCKET: ${{ github.event.inputs.etl_bucket }}
-          ETL_PREFIX: ${{ github.event.inputs.etl_prefix || 'data-gen' }}
-          SCALE_FACTOR: ${{ github.event.inputs.scale_factor || '1.0' }}
-          ETL_REGION: ${{ github.event.inputs.etl_region || 'us-east-1' }}
+          NUM_QUERY_CLIENTS: '8'
+          ETL_BUCKET: 'spicebench'
+          ETL_PREFIX: ${{ github.event.inputs.etl_type == 'mutations' && 'data-gen-mutable' || 'data-gen' }}
+          SCALE_FACTOR: ${{ github.event.inputs.scale_factor || '1' }}
+          ETL_REGION: 'us-east-1'
           ETL_SINK: 'adbc'
           SCHEDULER_STATE_LOCATION: 's3://spiceai-testing-cluster-state/spicebench-scheduler-state-${{ github.run_id }}/'
-          VALIDATE_CHECKPOINT_RESULTS: ${{ github.event.inputs.validate_checkpoint_results || 'false' }}
+          VALIDATE_CHECKPOINT_RESULTS: 'true'
           ENABLE_MODULE_DEBUG_LOGGING: ${{ github.event.inputs.enable_module_debug_logging || 'false' }}
-          SCRAPE_SUT_METRICS: ${{ github.event.inputs.scrape_sut_metrics || 'true' }}
+          SCRAPE_SUT_METRICS: 'true'
           SPICEAI_BENCHMARK_METRICS_KEY: ${{ secrets.SPICEAI_BENCHMARK_METRICS_KEY }}
           MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
           AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_ACCESS_KEY_ID }}


### PR DESCRIPTION
Simplify the workflow dispatch inputs for `run_spicebench.yml`:

<img width="328" height="526" alt="Screenshot 2026-03-18 at 12 18 30 PM" src="https://github.com/user-attachments/assets/58b38a24-60f4-4ef8-a267-59a2285312d7" />

- **Remove S3 bucket input** — hardcode to `spicebench` (kept as env var for easy re-addition)
- **Replace S3 key prefix** with an **ETL type** dropdown: `append-only` (→ `data-gen`) or `mutations` (→ `data-gen-mutable`)
- **Simplify Scale Factor** — choice dropdown of `0.1`, `1` (default), `10` instead of freeform string
- **Remove AWS region input** — hardcode to `us-east-1`
- **Remove concurrency input** — hardcode to `8`
- **Always enable** checkpoint-based result validation
- **Always enable** periodic SUT metrics collection
- **Rename** debug logging parameter to "Enable debug logs"