### PR TITLE
fix: Use spec-correct ADBC table name for bulk ingest

### DIFF
--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -285,6 +285,7 @@ jobs:
             export SPICEBENCH_ADBC_UPDATE_STRATEGY=staging_table
             export SPICEBENCH_TARGET_BATCH_ROWS=500000
             export SPICEBENCH_ADBC_MAX_INGEST_BATCH_BYTES=1268435456
+            export SPICEBENCH_ADBC_REUSE_BULK_INGEST_STREAMS=false
             ADAPTER_CMD="${HOME}/.spice/bin/databricks-system-adapter"
             ADAPTER_ARGS="stdio"
             ADAPTER_ENVS="--system-adapter-env DATABRICKS_ENDPOINT=${DATABRICKS_ENDPOINT} --system-adapter-env DATABRICKS_TOKEN=${DATABRICKS_TOKEN} --system-adapter-env DATABRICKS_HTTP_PATH=${DATABRICKS_HTTP_PATH} --system-adapter-env DATABRICKS_SQL_WAREHOUSE_ID=${DATABRICKS_SQL_WAREHOUSE_ID} --system-adapter-env DATABRICKS_TABLE_FORMAT=${DATABRICKS_TABLE_FORMAT}"

--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -303,6 +303,7 @@ jobs:
           else
             export SPICEBENCH_ADBC_UPDATE_STRATEGY=bulk_ingest_upsert
             export SPICEBENCH_ADBC_DELETE_BATCH_SIZE=50000
+            export SPICEBENCH_ADBC_QUALIFY_TABLE_NAME=true
             ADAPTER_CMD="docker"
             ADAPTER_ARGS="run -i -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL -e AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY} -e SPIDAPTER_ICEBERG_REGION -e SPIDAPTER_ICEBERG_CATALOG_FROM -e SCHEDULER_STATE_LOCATION ghcr.io/spiceai/spidapter:latest stdio --verbose --channel nightly"
             ADAPTER_ENVS=""

--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -303,7 +303,6 @@ jobs:
           else
             export SPICEBENCH_ADBC_UPDATE_STRATEGY=bulk_ingest_upsert
             export SPICEBENCH_ADBC_DELETE_BATCH_SIZE=50000
-            export SPICEBENCH_ADBC_QUALIFY_TABLE_NAME=true
             ADAPTER_CMD="docker"
             ADAPTER_ARGS="run -i -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL -e AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY} -e SPIDAPTER_ICEBERG_REGION -e SPIDAPTER_ICEBERG_CATALOG_FROM -e SCHEDULER_STATE_LOCATION ghcr.io/spiceai/spidapter:latest stdio --verbose --channel nightly"
             ADAPTER_ENVS=""

--- a/crates/adbc_client/src/lib.rs
+++ b/crates/adbc_client/src/lib.rs
@@ -216,6 +216,12 @@ impl AdbcConnection {
         mode: options::IngestMode,
         reader: Box<dyn arrow_array::RecordBatchReader + Send>,
     ) -> Result<Option<i64>> {
+        let reader: Box<dyn arrow_array::RecordBatchReader + Send> = if self.downcast_utf8view {
+            Box::new(DowncastUtf8ViewReader::new(reader))
+        } else {
+            reader
+        };
+
         let mut stmt = self.conn.new_statement().map_err(|e| Error::ExecuteQuery {
             reason: e.to_string(),
         })?;
@@ -290,6 +296,48 @@ fn downcast_utf8view(batch: &RecordBatch) -> RecordBatch {
     }
 
     RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).unwrap()
+}
+
+/// Wraps a [`RecordBatchReader`] and casts any `Utf8View` columns to `Utf8`
+/// on each yielded batch.
+struct DowncastUtf8ViewReader {
+    inner: Box<dyn arrow_array::RecordBatchReader + Send>,
+    schema: Arc<Schema>,
+}
+
+impl DowncastUtf8ViewReader {
+    fn new(inner: Box<dyn arrow_array::RecordBatchReader + Send>) -> Self {
+        let original_schema = inner.schema();
+        let fields: Vec<Arc<Field>> = original_schema
+            .fields()
+            .iter()
+            .map(|f| {
+                if matches!(f.data_type(), DataType::Utf8View) {
+                    Arc::new(Field::new(f.name(), DataType::Utf8, f.is_nullable()))
+                } else {
+                    f.clone()
+                }
+            })
+            .collect();
+        let schema = Arc::new(Schema::new(fields));
+        Self { inner, schema }
+    }
+}
+
+impl Iterator for DowncastUtf8ViewReader {
+    type Item = std::result::Result<RecordBatch, arrow::error::ArrowError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|result| result.map(|batch| downcast_utf8view(&batch)))
+    }
+}
+
+impl arrow_array::RecordBatchReader for DowncastUtf8ViewReader {
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
 }
 
 /// Returns `true` if the field is a `Utf8` column that represents a

--- a/crates/etl/src/sink/adbc.rs
+++ b/crates/etl/src/sink/adbc.rs
@@ -62,6 +62,12 @@ const ADBC_REUSE_BULK_INGEST_STREAMS_ENV: &str = "SPICEBENCH_ADBC_REUSE_BULK_ING
 const DEFAULT_ADBC_BULK_INGEST_STREAM_BUFFER: usize = 1;
 const ADBC_BULK_INGEST_STREAM_BUFFER_ENV: &str = "SPICEBENCH_ADBC_BULK_INGEST_STREAM_BUFFER";
 
+/// When `true`, the ADBC bulk ingest target table name is fully qualified as
+/// `catalog.schema.table` (for backends like Spice Cloud that expect dotted names
+/// in the `TargetTable` ADBC option). When `false` (default), the bare table name
+/// is used and catalog/schema are passed via separate ADBC options.
+const ADBC_QUALIFY_TABLE_NAME_ENV: &str = "SPICEBENCH_ADBC_QUALIFY_TABLE_NAME";
+
 /// Controls how UPDATE operations are executed.
 ///
 /// - `statement`          — row-by-row `UPDATE … SET … WHERE …` statements (default)
@@ -269,6 +275,8 @@ impl AdbcSink {
         let ingest_table_name = self.target_table_ingest_name(table_name);
         let source_table_name = table_name.to_string();
         let worker_schema = schema.clone();
+        let target_db_catalog = self.target_db_catalog.clone();
+        let target_db_schema = self.target_db_schema.clone();
 
         let worker = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             let mut conn = pool
@@ -277,8 +285,8 @@ impl AdbcSink {
 
             conn.bulk_ingest_stream(
                 &ingest_table_name,
-                None,
-                None,
+                target_db_catalog.as_deref(),
+                target_db_schema.as_deref(),
                 IngestMode::CreateAppend,
                 Box::new(ChannelRecordBatchReader::new(worker_schema, receiver)),
             )
@@ -457,8 +465,26 @@ impl AdbcSink {
         parts.join(".")
     }
 
+    fn qualify_table_name() -> bool {
+        std::env::var(ADBC_QUALIFY_TABLE_NAME_ENV)
+            .ok()
+            .and_then(|raw| {
+                let val = raw.trim().to_ascii_lowercase();
+                match val.as_str() {
+                    "1" | "true" | "yes" | "on" => Some(true),
+                    "0" | "false" | "no" | "off" => Some(false),
+                    _ => None,
+                }
+            })
+            .unwrap_or(false)
+    }
+
     fn target_table_ingest_name(&self, table_name: &str) -> String {
-        self.target_table_identifier_unquoted(table_name)
+        if Self::qualify_table_name() {
+            self.target_table_identifier_unquoted(table_name)
+        } else {
+            table_name.to_string()
+        }
     }
 
     fn target_table_identifier_unquoted(&self, table_name: &str) -> String {

--- a/crates/etl/src/sink/adbc.rs
+++ b/crates/etl/src/sink/adbc.rs
@@ -62,12 +62,6 @@ const ADBC_REUSE_BULK_INGEST_STREAMS_ENV: &str = "SPICEBENCH_ADBC_REUSE_BULK_ING
 const DEFAULT_ADBC_BULK_INGEST_STREAM_BUFFER: usize = 1;
 const ADBC_BULK_INGEST_STREAM_BUFFER_ENV: &str = "SPICEBENCH_ADBC_BULK_INGEST_STREAM_BUFFER";
 
-/// When `true`, the ADBC bulk ingest target table name is fully qualified as
-/// `catalog.schema.table` (for backends like Spice Cloud that expect dotted names
-/// in the `TargetTable` ADBC option). When `false` (default), the bare table name
-/// is used and catalog/schema are passed via separate ADBC options.
-const ADBC_QUALIFY_TABLE_NAME_ENV: &str = "SPICEBENCH_ADBC_QUALIFY_TABLE_NAME";
-
 /// Controls how UPDATE operations are executed.
 ///
 /// - `statement`          — row-by-row `UPDATE … SET … WHERE …` statements (default)
@@ -465,45 +459,8 @@ impl AdbcSink {
         parts.join(".")
     }
 
-    fn qualify_table_name() -> bool {
-        std::env::var(ADBC_QUALIFY_TABLE_NAME_ENV)
-            .ok()
-            .and_then(|raw| {
-                let val = raw.trim().to_ascii_lowercase();
-                match val.as_str() {
-                    "1" | "true" | "yes" | "on" => Some(true),
-                    "0" | "false" | "no" | "off" => Some(false),
-                    _ => None,
-                }
-            })
-            .unwrap_or(false)
-    }
-
     fn target_table_ingest_name(&self, table_name: &str) -> String {
-        if Self::qualify_table_name() {
-            self.target_table_identifier_unquoted(table_name)
-        } else {
-            table_name.to_string()
-        }
-    }
-
-    fn target_table_identifier_unquoted(&self, table_name: &str) -> String {
-        let mut parts = Vec::with_capacity(3);
-
-        if let Some(catalog) = self.target_db_catalog.as_deref()
-            && !catalog.is_empty()
-        {
-            parts.push(catalog.to_string());
-        }
-
-        if let Some(schema) = self.target_db_schema.as_deref()
-            && !schema.is_empty()
-        {
-            parts.push(schema.to_string());
-        }
-
-        parts.push(table_name.to_string());
-        parts.join(".")
+        table_name.to_string()
     }
 
     fn create_table_sql(


### PR DESCRIPTION
## 🗣 Description

Fixes ADBC bulk ingest to use a bare table name in `TargetTable` with catalog and schema passed via separate `TargetCatalog`/`TargetDbSchema` options, per the ADBC spec. Previously, the table name was fully qualified as `catalog.schema.table` in `TargetTable`, which is non-standard and rejected by drivers like Databricks (`INVALID_PARAMETER_VALUE` in `CreateStagingTable`).

SpiceCloud  run: https://github.com/spiceai/spicebench/actions/runs/23258976819

~Databricks run: https://github.com/spiceai/spicebench/actions/runs/23258604493/job/67620563987~
>Checkpoint 0: full query set validation failed, returning to probe phase
  FAIL - query 'tpch_q8': NoExpectedAnswer

Databricks (`SPICEBENCH_ADBC_REUSE_BULK_INGEST_STREAMS=false`):  https://github.com/spiceai/spicebench/actions/runs/23259599985/job/67624159652

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
