### PR TITLE
Add no teardown arg to spicebench and an option to debug_spice_cloud to keep spidapter instance after the run

### DIFF
--- a/.github/workflows/run_spicebench_debug_spice_cloud.yml
+++ b/.github/workflows/run_spicebench_debug_spice_cloud.yml
@@ -43,6 +43,11 @@ on:
         required: false
         default: false
         type: boolean
+      disable_teardown:
+        description: 'Skip the teardown RPC call to the system adapter'
+        required: false
+        default: false
+        type: boolean
 jobs:
   run-spicebench:
     name: Run spicebench
@@ -128,6 +133,7 @@ jobs:
           S3_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SPIDAPTER_ICEBERG_REGION: us-west-1
           SPIDAPTER_ICEBERG_CATALOG_FROM: iceberg:https://glue.us-west-1.amazonaws.com/iceberg/v1/catalogs/211125479522/namespaces
+          DISABLE_TEARDOWN: ${{ github.event.inputs.disable_teardown || 'false' }}
         run: |
           set -euo pipefail
           if [ "${ENABLE_MODULE_DEBUG_LOGGING}" = "true" ]; then
@@ -173,6 +179,11 @@ jobs:
           ADAPTER_ARGS="run -i -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL -e AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY} -e SPIDAPTER_ICEBERG_REGION -e SPIDAPTER_ICEBERG_CATALOG_FROM -e SCHEDULER_STATE_LOCATION ghcr.io/spiceai/spidapter:${{ github.event.inputs.spidapter_version || 'latest' }} stdio --verbose --channel nightly"
           ADAPTER_ENVS=""
 
+          NO_TEARDOWN_ARG=""
+          if [ "${DISABLE_TEARDOWN}" = "true" ]; then
+            NO_TEARDOWN_ARG="--no-teardown"
+          fi
+
           ~/.spice/bin/spicebench run \
             --concurrency "${NUM_QUERY_CLIENTS}"  \
             --scenario "${SCENARIO}" \
@@ -185,3 +196,4 @@ jobs:
             --system-adapter-stdio-args "${ADAPTER_ARGS}" \
             ${ADAPTER_ENVS} \
             ${SCHEDULER_STATE_ADAPTER_ENV} \
+            ${NO_TEARDOWN_ARG} \

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -181,6 +181,13 @@ pub struct RunArgs {
     /// when individual query latency is high.
     #[arg(long, default_value_t = 5)]
     pub(crate) checkpoint_validation_period: u64,
+
+    /// Skip the teardown RPC call to the system adapter after the benchmark completes.
+    ///
+    /// Useful when you want to inspect the system state after a run without
+    /// triggering adapter-side cleanup (e.g. for debugging spice_cloud deployments).
+    #[arg(long, default_value_t = false)]
+    pub(crate) no_teardown: bool,
 }
 
 fn parse_key_val(s: &str) -> Result<(String, String), String> {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -390,8 +390,11 @@ pub async fn execute(args: &RunArgs) -> anyhow::Result<()> {
     )
     .await;
 
-    // After successful setup, always teardown even if there are errors in between.
-    if let Err(e) = system_adapter_client.lock().await.teardown(run_id).await {
+    // After successful setup, always teardown even if there are errors in between,
+    // unless --no-teardown was requested (e.g. to inspect cloud state after a run).
+    if args.no_teardown {
+        tracing::info!("Skipping teardown (--no-teardown flag is set).");
+    } else if let Err(e) = system_adapter_client.lock().await.teardown(run_id).await {
         tracing::error!("Failed to teardown system adapter: {e}");
     }
 


### PR DESCRIPTION
This pull request adds a new option to skip the teardown step after running the `spicebench` benchmark, which is useful for debugging and inspecting the system state after a run. The change introduces a `--no-teardown` flag in the CLI and propagates this option through the GitHub Actions workflow and the application logic.

**Workflow and CLI enhancements:**

* Added a `disable_teardown` input to the GitHub Actions workflow (`.github/workflows/run_spicebench_debug_spice_cloud.yml`), allowing users to skip the teardown RPC call to the system adapter.
* Passed the `disable_teardown` input as the `DISABLE_TEARDOWN` environment variable in the workflow, and updated the workflow script to include a `--no-teardown` argument for `spicebench` when this option is set. [[1]](diffhunk://#diff-8e35ea621a3768475f93baa4ee7aba1784a733d11898144b232c948c01d98777R136) [[2]](diffhunk://#diff-8e35ea621a3768475f93baa4ee7aba1784a733d11898144b232c948c01d98777R182-R186) [[3]](diffhunk://#diff-8e35ea621a3768475f93baa4ee7aba1784a733d11898144b232c948c01d98777R199)

**Application logic:**

* Added a `no_teardown` boolean flag to the `RunArgs` struct, exposed as the `--no-teardown` CLI argument.
* Updated the `run` command logic to respect the `--no-teardown` flag, skipping the teardown step and logging a message when the flag is set.