### PR TITLE
Add Spice Cloud Prod option to debug run workflow

### DIFF
--- a/.github/workflows/run_spicebench_debug_spice_cloud.yml
+++ b/.github/workflows/run_spicebench_debug_spice_cloud.yml
@@ -68,7 +68,7 @@ jobs:
 
       - uses: ./.github/actions/management-login
         with:
-          token-url: ${{ github.event.inputs.environment == 'prod' && 'https://api.spice.ai/oauth/token' || 'https://dev-api.spice.ai/oauth/token' }}
+          token-url: ${{ github.event.inputs.environment == 'prod' && 'https://spice.ai/api/oauth/token' || 'https://dev.spice.ai/api/oauth/token' }}
           client-id: ${{ github.event.inputs.environment == 'prod' && secrets.SPICE_MANAGEMENT_CLIENT_ID_PROD || secrets.SPICE_MANAGEMENT_CLIENT_ID }}
           client-secret: ${{ github.event.inputs.environment == 'prod' && secrets.SPICE_MANAGEMENT_CLIENT_SECRET_PROD || secrets.SPICE_MANAGEMENT_CLIENT_SECRET }}
 

--- a/.github/workflows/run_spicebench_debug_spice_cloud.yml
+++ b/.github/workflows/run_spicebench_debug_spice_cloud.yml
@@ -12,7 +12,7 @@ on:
         options:
           - spice_cloud
       environment:
-        description: 'Target environment'
+        description: 'Target Spice Cloud Environment'
         required: true
         default: 'dev'
         type: choice
@@ -68,6 +68,7 @@ jobs:
 
       - uses: ./.github/actions/management-login
         with:
+          token-url: ${{ github.event.inputs.environment == 'prod' && 'https://api.spice.ai/oauth/token' || 'https://dev-api.spice.ai/oauth/token' }}
           client-id: ${{ github.event.inputs.environment == 'prod' && secrets.SPICE_MANAGEMENT_CLIENT_ID_PROD || secrets.SPICE_MANAGEMENT_CLIENT_ID }}
           client-secret: ${{ github.event.inputs.environment == 'prod' && secrets.SPICE_MANAGEMENT_CLIENT_SECRET_PROD || secrets.SPICE_MANAGEMENT_CLIENT_SECRET }}
 

--- a/.github/workflows/run_spicebench_debug_spice_cloud.yml
+++ b/.github/workflows/run_spicebench_debug_spice_cloud.yml
@@ -11,6 +11,14 @@ on:
         type: choice
         options:
           - spice_cloud
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - prod
       scenario:
         description: 'Scenario/query set to run (e.g. tpch)'
         required: true
@@ -60,8 +68,8 @@ jobs:
 
       - uses: ./.github/actions/management-login
         with:
-          client-id: ${{ secrets.SPICE_MANAGEMENT_CLIENT_ID }}
-          client-secret: ${{ secrets.SPICE_MANAGEMENT_CLIENT_SECRET }}
+          client-id: ${{ github.event.inputs.environment == 'prod' && secrets.SPICE_MANAGEMENT_CLIENT_ID_PROD || secrets.SPICE_MANAGEMENT_CLIENT_ID }}
+          client-secret: ${{ github.event.inputs.environment == 'prod' && secrets.SPICE_MANAGEMENT_CLIENT_SECRET_PROD || secrets.SPICE_MANAGEMENT_CLIENT_SECRET }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -79,7 +87,7 @@ jobs:
         env:
           SCENARIO: ${{ github.event.inputs.scenario || 'tpch' }}
           SPICEAI_API_KEY: ${{ env.SPICEAI_API_KEY }}
-          SPICE_CLOUD_API_URL: https://dev-api.spice.ai
+          SPICE_CLOUD_API_URL: ${{ github.event.inputs.environment == 'prod' && 'https://api.spice.ai' || 'https://dev-api.spice.ai' }}
         run: |
           set -euo pipefail
 
@@ -111,7 +119,7 @@ jobs:
       - name: Run spicebench
         env:
           SPICEAI_API_KEY: ${{ env.SPICEAI_API_KEY }}
-          SPICE_CLOUD_API_URL: https://dev-api.spice.ai
+          SPICE_CLOUD_API_URL: ${{ github.event.inputs.environment == 'prod' && 'https://api.spice.ai' || 'https://dev-api.spice.ai' }}
           SCENARIO: ${{ github.event.inputs.scenario || 'tpch' }}
           SYSTEM_UNDER_TEST: ${{ github.event.inputs.system_under_test || 'spice_cloud' }}
           SYSTEM_ADAPTER: ${{ github.event.inputs.system_under_test || 'spice_cloud' }}


### PR DESCRIPTION
This pull request enhances the `run_spicebench_debug_spice_cloud.yml` GitHub Actions workflow by introducing support for selecting the target environment (dev or prod) and dynamically configuring credentials and API endpoints based on the chosen environment. This makes the workflow more flexible and suitable for both development and production use cases.

**Environment selection and dynamic configuration:**

* Added a new `environment` input to the workflow, allowing users to choose between `dev` and `prod` environments when running the workflow.
* Updated the management login step to use the appropriate client ID and secret based on the selected environment, switching to production credentials if `prod` is chosen.
* Modified the `SPICE_CLOUD_API_URL` environment variable in relevant steps to point to either the production or development API endpoint, depending on the selected environment. [[1]](diffhunk://#diff-8e35ea621a3768475f93baa4ee7aba1784a733d11898144b232c948c01d98777L82-R90) [[2]](diffhunk://#diff-8e35ea621a3768475f93baa4ee7aba1784a733d11898144b232c948c01d98777L114-R122)