### PR TITLE
Add deterministic checkpoint validation for mutable runs

### DIFF
--- a/crates/checkpointer/src/lib.rs
+++ b/crates/checkpointer/src/lib.rs
@@ -22,6 +22,7 @@ limitations under the License.
 //!
 //! ```text
 //! s3://{bucket}/{prefix}/{scenario}/{version}/checkpoints/{checkpoint_idx}/{query_idx}.parquet
+//! s3://{bucket}/{prefix}/{scenario}/{version}/checkpoints/{checkpoint_idx}/row_counts.json
 //! s3://{bucket}/{prefix}/{scenario}/{version}/checkpoints.json          ← manifest
 //! ```
 //!
@@ -123,6 +124,10 @@ impl CheckpointStore {
         self.object_path(&format!("checkpoints/{checkpoint_idx}/{query_idx}.parquet"))
     }
 
+    fn checkpoint_row_counts_path(&self, checkpoint_idx: usize) -> ObjectPath {
+        self.object_path(&format!("checkpoints/{checkpoint_idx}/row_counts.json"))
+    }
+
     /// Upload all checkpoint parquet files from `local_checkpoint_dir` to S3,
     /// then update (merge into) the manifest at `{prefix}/checkpoints.json`.
     ///
@@ -198,6 +203,19 @@ impl CheckpointStore {
                 query_indexes_set.insert(q_idx);
             }
 
+            let row_counts_path = checkpoint_entry.path().join("row_counts.json");
+            if row_counts_path.exists() {
+                let bytes = std::fs::read(&row_counts_path)?;
+                let dest = self.checkpoint_row_counts_path(checkpoint_idx);
+                tracing::info!(
+                    scenario,
+                    checkpoint = checkpoint_idx,
+                    dest = %dest,
+                    "Uploading checkpoint row counts"
+                );
+                self.store.put(&dest, PutPayload::from(bytes)).await?;
+            }
+
             checkpoint_indexes.push(checkpoint_idx);
         }
 
@@ -269,6 +287,29 @@ impl CheckpointStore {
                     path = %local_path.display(),
                     "Downloaded checkpoint parquet"
                 );
+            }
+
+            let row_counts_remote = self.checkpoint_row_counts_path(checkpoint_idx);
+            match self.store.get(&row_counts_remote).await {
+                Ok(object) => {
+                    let data = object.bytes().await?;
+                    let local_path = checkpoint_dir.join("row_counts.json");
+                    std::fs::write(&local_path, &data)?;
+                    tracing::info!(
+                        scenario,
+                        checkpoint = checkpoint_idx,
+                        path = %local_path.display(),
+                        "Downloaded checkpoint row counts"
+                    );
+                }
+                Err(object_store::Error::NotFound { .. }) => {
+                    tracing::debug!(
+                        scenario,
+                        checkpoint = checkpoint_idx,
+                        "Checkpoint row counts not found, skipping"
+                    );
+                }
+                Err(err) => return Err(err.into()),
             }
         }
 

--- a/crates/test-framework/src/queries/tpch/hadoop/q18.sql
+++ b/crates/test-framework/src/queries/tpch/hadoop/q18.sql
@@ -29,4 +29,5 @@ group by
     o_totalprice
 order by
     o_totalprice desc,
-    o_orderdate;
+    o_orderdate,
+    o_orderkey;

--- a/crates/test-framework/src/queries/tpch/iceberg_sf1/q18.sql
+++ b/crates/test-framework/src/queries/tpch/iceberg_sf1/q18.sql
@@ -29,4 +29,5 @@ group by
     o_totalprice
 order by
     o_totalprice desc,
-    o_orderdate;
+    o_orderdate,
+    o_orderkey;

--- a/crates/test-framework/src/queries/tpch/parameterized/q18.sql
+++ b/crates/test-framework/src/queries/tpch/parameterized/q18.sql
@@ -29,4 +29,5 @@ group by
     o_totalprice
 order by
     o_totalprice desc,
-    o_orderdate;
+    o_orderdate,
+    o_orderkey;

--- a/crates/test-framework/src/queries/tpch/q18.sql
+++ b/crates/test-framework/src/queries/tpch/q18.sql
@@ -29,4 +29,5 @@ group by
     o_totalprice
 order by
     o_totalprice desc,
-    o_orderdate;
+    o_orderdate,
+    o_orderkey;

--- a/crates/test-framework/src/queries/tpch/spicecloud_catalog/q18.sql
+++ b/crates/test-framework/src/queries/tpch/spicecloud_catalog/q18.sql
@@ -29,4 +29,5 @@ group by
     o_totalprice
 order by
     o_totalprice desc,
-    o_orderdate;
+    o_orderdate,
+    o_orderkey;

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -28,6 +28,8 @@ use checkpointer::CheckpointStore;
 #[cfg(feature = "duckdb")]
 use data_generation::config::{TargetConfig, build_version_prefix};
 #[cfg(feature = "duckdb")]
+use data_generation::dataset::Dataset;
+#[cfg(feature = "duckdb")]
 use data_generation::storage::DataStorage;
 #[cfg(feature = "duckdb")]
 use data_generation::storage::file::FileStorage;
@@ -103,6 +105,57 @@ fn write_batches_to_parquet(
     Ok(())
 }
 
+#[cfg(feature = "duckdb")]
+fn extract_row_count_value(batches: &[RecordBatch]) -> anyhow::Result<usize> {
+    let batch = batches
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("row count query returned no batches"))?;
+    if batch.num_rows() == 0 || batch.num_columns() == 0 {
+        anyhow::bail!("row count query returned an empty result set");
+    }
+
+    let value = test_framework::queries::validation::array_value_to_string(
+        batch.column(0).as_ref(),
+        0,
+    )?
+    .ok_or_else(|| anyhow::anyhow!("row count query returned NULL"))?;
+
+    value
+        .parse::<usize>()
+        .map_err(|e| anyhow::anyhow!("failed to parse row count '{value}': {e}"))
+}
+
+#[cfg(feature = "duckdb")]
+async fn write_checkpoint_row_counts(
+    sink: &DuckDBSink,
+    table_names: &[String],
+    checkpoint_dir: &Path,
+    checkpoint_idx: usize,
+) -> anyhow::Result<()> {
+    let resolved_checkpoint_dir = checkpoint_dir.join(checkpoint_idx.to_string());
+    fs::create_dir_all(&resolved_checkpoint_dir)?;
+
+    let mut row_counts = std::collections::BTreeMap::new();
+    for table_name in table_names {
+        let sql = format!("SELECT COUNT(*) AS row_count FROM \"{table_name}\"");
+        let batches = sink.query(&sql).await?;
+        let row_count = extract_row_count_value(&batches)?;
+        row_counts.insert(table_name.clone(), row_count);
+    }
+
+    let out_path = resolved_checkpoint_dir.join("row_counts.json");
+    fs::write(&out_path, serde_json::to_vec_pretty(&row_counts)?)?;
+
+    tracing::info!(
+        checkpoint = checkpoint_idx,
+        tables = row_counts.len(),
+        path = %out_path.display(),
+        "Checkpoint table row counts written"
+    );
+
+    Ok(())
+}
+
 pub async fn execute(args: &CheckpointArgs) -> anyhow::Result<()> {
     #[cfg(not(feature = "duckdb"))]
     {
@@ -153,6 +206,10 @@ async fn execute_duckdb(args: &CheckpointArgs) -> anyhow::Result<()> {
     let dataset_source = DatasetSource::from_dataset_type(&version_metadata.dataset_type)?;
     let dataset_config = version_metadata.dataset_config();
     let mutations = version_metadata.mutation_config();
+    let dataset = dataset_source.create(&dataset_config, &mutations, Arc::clone(&source))?;
+    let mut table_names: Vec<String> = dataset.tables().keys().cloned().collect();
+    table_names.sort();
+
     let target = Arc::new(DuckDBSink::new(&args.duckdb_path)?);
     let target_sink: Arc<dyn etl::sink::Sink> = Arc::clone(&target) as Arc<dyn etl::sink::Sink>;
 
@@ -203,6 +260,13 @@ async fn execute_duckdb(args: &CheckpointArgs) -> anyhow::Result<()> {
                     checkpoint_idx,
                 )
                 .await?;
+                write_checkpoint_row_counts(
+                    &target,
+                    &table_names,
+                    &args.checkpoint_dir,
+                    checkpoint_idx,
+                )
+                .await?;
                 checkpoint_idx += 1;
 
                 pipeline.continue_pipeline()?;
@@ -215,6 +279,13 @@ async fn execute_duckdb(args: &CheckpointArgs) -> anyhow::Result<()> {
                 run_checkpoint_queries(
                     &target,
                     &checkpoint_queries,
+                    &args.checkpoint_dir,
+                    checkpoint_idx,
+                )
+                .await?;
+                write_checkpoint_row_counts(
+                    &target,
+                    &table_names,
                     &args.checkpoint_dir,
                     checkpoint_idx,
                 )

--- a/src/commands/checkpoint.rs
+++ b/src/commands/checkpoint.rs
@@ -114,11 +114,9 @@ fn extract_row_count_value(batches: &[RecordBatch]) -> anyhow::Result<usize> {
         anyhow::bail!("row count query returned an empty result set");
     }
 
-    let value = test_framework::queries::validation::array_value_to_string(
-        batch.column(0).as_ref(),
-        0,
-    )?
-    .ok_or_else(|| anyhow::anyhow!("row count query returned NULL"))?;
+    let value =
+        test_framework::queries::validation::array_value_to_string(batch.column(0).as_ref(), 0)?
+            .ok_or_else(|| anyhow::anyhow!("row count query returned NULL"))?;
 
     value
         .parse::<usize>()

--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -307,6 +307,109 @@ fn load_checkpoint_results(
     Ok(results)
 }
 
+fn load_checkpoint_row_counts(
+    checkpoint_dir: &Path,
+    checkpoint_idx: usize,
+) -> anyhow::Result<HashMap<String, usize>> {
+    let idx_dir = checkpoint_dir.join(checkpoint_idx.to_string());
+    let row_counts_path = idx_dir.join("row_counts.json");
+    if !row_counts_path.exists() {
+        return Ok(HashMap::new());
+    }
+
+    Ok(serde_json::from_slice(&std::fs::read(row_counts_path)?)?)
+}
+
+fn checkpoint_count_query(
+    table_name: &str,
+    query_catalog_namespace: Option<&str>,
+) -> test_framework::queries::Query {
+    let qualified_table = match query_catalog_namespace.map(str::trim) {
+        Some(namespace) if !namespace.is_empty() => format!("{namespace}.\"{table_name}\""),
+        _ => format!("\"{table_name}\""),
+    };
+
+    test_framework::queries::Query::new(
+        format!("checkpoint_row_count_{table_name}").into(),
+        format!("SELECT COUNT(*) AS row_count FROM {qualified_table}").into(),
+        false,
+    )
+}
+
+fn extract_row_count_from_batches(batches: &[RecordBatch]) -> anyhow::Result<usize> {
+    let batch = batches
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("row count query returned no batches"))?;
+    if batch.num_rows() == 0 || batch.num_columns() == 0 {
+        anyhow::bail!("row count query returned an empty result set");
+    }
+
+    let value = validation::array_value_to_string(batch.column(0).as_ref(), 0)?
+        .ok_or_else(|| anyhow::anyhow!("row count query returned NULL"))?;
+    value
+        .parse::<usize>()
+        .map_err(|e| anyhow::anyhow!("failed to parse row count '{value}': {e}"))
+}
+
+async fn validate_checkpoint_table_row_counts(
+    executor: &dyn QueryExecutor,
+    expected_row_counts: &HashMap<String, usize>,
+    checkpoint_idx: usize,
+    query_catalog_namespace: Option<&str>,
+) -> bool {
+    if expected_row_counts.is_empty() {
+        println!(
+            "Checkpoint {checkpoint_idx}: no table row counts found, skipping row-count validation"
+        );
+        return true;
+    }
+
+    let mut tables: Vec<_> = expected_row_counts.iter().collect();
+    tables.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    for (table_name, expected_count) in tables {
+        let query = checkpoint_count_query(table_name, query_catalog_namespace);
+        let result = match executor.execute(&query).await {
+            Ok(result) => result,
+            Err(err) => {
+                eprintln!(
+                    "Checkpoint {checkpoint_idx}: row count query for table '{table_name}' failed: {err}"
+                );
+                return false;
+            }
+        };
+
+        let Some(batches) = result.batches.as_ref() else {
+            eprintln!(
+                "Checkpoint {checkpoint_idx}: row count query for table '{table_name}' did not return batches"
+            );
+            return false;
+        };
+
+        let actual_count = match extract_row_count_from_batches(batches) {
+            Ok(count) => count,
+            Err(err) => {
+                eprintln!(
+                    "Checkpoint {checkpoint_idx}: failed to read row count for table '{table_name}': {err}"
+                );
+                return false;
+            }
+        };
+
+        if actual_count != *expected_count {
+            eprintln!(
+                "Checkpoint {checkpoint_idx}: table '{table_name}' row count mismatch: expected {expected_count}, actual {actual_count}"
+            );
+            return false;
+        }
+    }
+
+    println!(
+        "Checkpoint {checkpoint_idx}: table row counts passed, validating full query set"
+    );
+    true
+}
+
 /// Result of a checkpoint validation window.
 enum CheckpointValidationResult {
     /// Validation converged — full query set passed.
@@ -524,11 +627,13 @@ async fn run_checkpoint_validation(
     executor: &dyn QueryExecutor,
     queries: &[test_framework::queries::Query],
     expected_results: &HashMap<Arc<str>, Vec<RecordBatch>>,
+    expected_row_counts: &HashMap<String, usize>,
     checkpoint_idx: usize,
     concurrency: usize,
     probe_period: Duration,
     max_wait: Duration,
     checkpoint_pause_time: std::time::Instant,
+    query_catalog_namespace: Option<&str>,
 ) -> CheckpointValidationResult {
     let deadline = tokio::time::Instant::now() + max_wait;
 
@@ -565,7 +670,7 @@ async fn run_checkpoint_validation(
         {
             ProbeOutcome::Passed(send_time) => {
                 println!(
-                    "Checkpoint {checkpoint_idx}: probe query '{}' passed, validating full query set",
+                    "Checkpoint {checkpoint_idx}: probe query '{}' passed, validating table row counts",
                     probe_query.name
                 );
                 send_time
@@ -577,6 +682,17 @@ async fn run_checkpoint_validation(
         // Phase 2: validate the full query set
         if tokio::time::Instant::now() >= deadline {
             return CheckpointValidationResult::TimedOut;
+        }
+
+        if !validate_checkpoint_table_row_counts(
+            executor,
+            expected_row_counts,
+            checkpoint_idx,
+            query_catalog_namespace,
+        )
+        .await
+        {
+            continue;
         }
 
         if validate_full_query_set(
@@ -791,9 +907,13 @@ pub(crate) async fn run(
                         {
                             match load_checkpoint_results(cp_dir, checkpoint_idx, &query_names) {
                                 Ok(expected_results) if !expected_results.is_empty() => {
+                                    let expected_row_counts =
+                                        load_checkpoint_row_counts(cp_dir, checkpoint_idx)
+                                            .unwrap_or_default();
                                     tracing::info!(
                                         checkpoint_idx,
                                         num_queries = expected_results.len(),
+                                        num_tables = expected_row_counts.len(),
                                         "Running checkpoint validation"
                                     );
 
@@ -803,11 +923,13 @@ pub(crate) async fn run(
                                         &validation_executor,
                                         &queries,
                                         &expected_results,
+                                        &expected_row_counts,
                                         checkpoint_idx,
                                         common_args.concurrency,
                                         Duration::from_secs(common_args.checkpoint_validation_period),
                                         Duration::from_secs(600),
                                         checkpoint_pause_time,
+                                        query_catalog_namespace.as_deref(),
                                     )
                                     .await;
 
@@ -868,9 +990,13 @@ pub(crate) async fn run(
                             let checkpoint_idx = etl_pipeline.checkpoint_idx();
                             match load_checkpoint_results(cp_dir, checkpoint_idx, &query_names) {
                                 Ok(expected_results) if !expected_results.is_empty() => {
+                                    let expected_row_counts =
+                                        load_checkpoint_row_counts(cp_dir, checkpoint_idx)
+                                            .unwrap_or_default();
                                     tracing::info!(
                                         checkpoint_idx,
                                         num_queries = expected_results.len(),
+                                        num_tables = expected_row_counts.len(),
                                         "Running final checkpoint validation"
                                     );
 
@@ -880,11 +1006,13 @@ pub(crate) async fn run(
                                         &validation_executor,
                                         &queries,
                                         &expected_results,
+                                        &expected_row_counts,
                                         checkpoint_idx,
                                         common_args.concurrency,
                                         Duration::from_secs(common_args.checkpoint_validation_period),
                                         Duration::from_secs(600),
                                         checkpoint_pause_time,
+                                        query_catalog_namespace.as_deref(),
                                     )
                                     .await;
 

--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -404,9 +404,7 @@ async fn validate_checkpoint_table_row_counts(
         }
     }
 
-    println!(
-        "Checkpoint {checkpoint_idx}: table row counts passed, validating full query set"
-    );
+    println!("Checkpoint {checkpoint_idx}: table row counts passed, validating full query set");
     true
 }
 


### PR DESCRIPTION
## Summary
- add `row_counts.json` generation/upload/download for checkpoints
- validate checkpoint table row counts after the q1 probe and before full query-set validation
- make TPC-H q18 deterministic by adding `o_orderkey` as a final tie-breaker across the query variants used by validation

## Validation
- `cargo build --release -p spicebench --features duckdb`
- `AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin ./target/release/spicebench checkpoint --scenario tpch --version 1.0 --bucket spicebench --prefix data-gen-mutable-sf1-10step --endpoint http://127.0.0.1:9000 --region us-east-1 --duckdb-path /tmp/tpch-checkpoint-10step.duckdb --checkpoint-interval-steps 10 --checkpoint-dir /tmp/checkpoints-10step-new`
- `AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin ./target/release/spicebench checkpoint --scenario tpch --version 1.0 --bucket spicebench --prefix data-gen-mutable-sf1 --endpoint http://127.0.0.1:9000 --region us-east-1 --duckdb-path /tmp/tpch-checkpoint-sf1-20step.duckdb --checkpoint-interval-steps 10 --checkpoint-dir /tmp/checkpoints-sf1-20step-new`
- local mutable validation passed with 4 executors for both:
  - `data-gen-mutable-sf1-10step`
  - `data-gen-mutable-sf1` (two consecutive successful runs)

## Notes
- The refreshed checkpoint artifacts were regenerated in object storage so validation now uses deterministic q18 outputs plus per-checkpoint row counts.
- Paired spiceai runtime PR: https://github.com/spiceai/spiceai/pull/9876
