### PR TITLE
fix: Increase memory limit, add spicehq organization tag, disable PVC

### DIFF
--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -238,8 +238,9 @@ jobs:
           LAKEBASE_BRANCH: ${{ vars.LAKEBASE_BRANCH }}
           SPIDAPTER_ICEBERG_REGION: us-west-1
           SPIDAPTER_ICEBERG_CATALOG_FROM: iceberg:https://glue.us-west-1.amazonaws.com/iceberg/v1/catalogs/211125479522/namespaces
-          SPIDAPTER_APP_MEMORY_LIMIT: '16Gi'
-          ENABLE_PVC: 'true'
+          SPIDAPTER_APP_MEMORY_LIMIT: '62Gi'
+          SPIDAPTER_EXECUTOR_MEMORY_LIMIT: '62Gi'
+          SPIDAPTER_EPHEMERAL_STORAGE_LIMIT: '256Gi'
         run: |
           set -euo pipefail
           if [ "${ENABLE_MODULE_DEBUG_LOGGING}" = "true" ]; then

--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -241,6 +241,7 @@ jobs:
           SPIDAPTER_APP_MEMORY_LIMIT: '62Gi'
           SPIDAPTER_EXECUTOR_MEMORY_LIMIT: '62Gi'
           SPIDAPTER_EPHEMERAL_STORAGE_LIMIT: '256Gi'
+          SPIDAPTER_ORGANIZATION_TAG: 'spicehq'
         run: |
           set -euo pipefail
           if [ "${ENABLE_MODULE_DEBUG_LOGGING}" = "true" ]; then

--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -242,6 +242,7 @@ jobs:
           SPIDAPTER_EXECUTOR_MEMORY_LIMIT: '62Gi'
           SPIDAPTER_EPHEMERAL_STORAGE_LIMIT: '256Gi'
           SPIDAPTER_ORGANIZATION_TAG: 'spicehq'
+          ENABLE_PVC: 'false'
         run: |
           set -euo pipefail
           if [ "${ENABLE_MODULE_DEBUG_LOGGING}" = "true" ]; then


### PR DESCRIPTION
## 🗣 Description

<!-- include a description about your pull request and changes, and why these changes need to be made -->

* Disables PVC generation to use increased ephemeral storage limits instead
* Increases the executor and scheduler memory limits
* Adds the `spicehq` organization tag