### PR TITLE
chore: Change default ETL type to changes in run workflow

### DIFF
--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -23,7 +23,7 @@ on:
       etl_type:
         description: 'ETL type'
         required: true
-        default: 'events'
+        default: 'changes'
         type: choice
         options:
           - events


### PR DESCRIPTION
Changes the default `etl_type` workflow input from `events` to `changes`, so the ETL prefix defaults to `data-gen-mutable`.