### PR TITLE
feat: Add custom_image input to debug Spice Cloud workflow

### DIFF
--- a/.github/workflows/run_spicebench_debug_spice_cloud.yml
+++ b/.github/workflows/run_spicebench_debug_spice_cloud.yml
@@ -46,6 +46,11 @@ on:
         required: false
         default: 'latest'
         type: string
+      num_query_clients:
+        description: 'Number of concurrent query clients'
+        required: false
+        default: '2'
+        type: string
       enable_module_debug_logging:
         description: 'Enable debug logs'
         required: false
@@ -61,10 +66,25 @@ on:
         required: false
         default: false
         type: boolean
+      executor_replicas:
+        description: 'Number of executor replicas'
+        required: false
+        default: '4'
+        type: string
       app_memory_limit:
         description: 'Memory limit for the scheduler (app) pod (e.g. 16Gi, 20Gi)'
         required: false
         default: '16Gi'
+        type: string
+      executor_memory_limit:
+        description: 'Memory limit for the executor pod (e.g. 16Gi, 62Gi)'
+        required: false
+        default: '16Gi'
+        type: string
+      custom_image:
+        description: 'Custom runtime container image (e.g. ghcr.io/spiceai/spiceai-dev:spicebench-sf10). Overrides the default channel image. Requires the internal update channel on the target SCP environment.'
+        required: false
+        default: ''
         type: string
 jobs:
   run-spicebench:
@@ -134,7 +154,7 @@ jobs:
           SCENARIO: ${{ github.event.inputs.scenario || 'tpch' }}
           SYSTEM_UNDER_TEST: ${{ github.event.inputs.system_under_test || 'spice_cloud' }}
           SYSTEM_ADAPTER: ${{ github.event.inputs.system_under_test || 'spice_cloud' }}
-          NUM_QUERY_CLIENTS: '8'
+          NUM_QUERY_CLIENTS: ${{ github.event.inputs.num_query_clients || '2' }}
           ETL_BUCKET: 'spicebench'
           ETL_PREFIX: ${{ github.event.inputs.etl_type == 'changes' && 'data-gen-mutable' || 'data-gen' }}
           SCALE_FACTOR: ${{ github.event.inputs.scale_factor || '1' }}
@@ -154,7 +174,10 @@ jobs:
           SPIDAPTER_ICEBERG_CATALOG_FROM: iceberg:https://glue.us-west-1.amazonaws.com/iceberg/v1/catalogs/211125479522/namespaces
           DISABLE_TEARDOWN: ${{ github.event.inputs.disable_teardown || 'false' }}
           ENABLE_PVC: ${{ github.event.inputs.enable_pvc || 'false' }}
+          EXECUTOR_REPLICAS: ${{ github.event.inputs.executor_replicas || '4' }}
           SPIDAPTER_APP_MEMORY_LIMIT: ${{ github.event.inputs.app_memory_limit || '16Gi' }}
+          SPIDAPTER_EXECUTOR_MEMORY_LIMIT: ${{ github.event.inputs.executor_memory_limit || '16Gi' }}
+          CUSTOM_IMAGE: ${{ github.event.inputs.custom_image || '' }}
         run: |
           set -euo pipefail
           if [ "${ENABLE_MODULE_DEBUG_LOGGING}" = "true" ]; then
@@ -198,16 +221,46 @@ jobs:
           export SPICEBENCH_ADBC_FLUSH_STREAM_BEFORE_UPSERT=true
           export SPICEBENCH_ADBC_DELETE_BATCH_SIZE=50000
           ADAPTER_CMD="docker"
-          ADAPTER_DOCKER_OPTS="run -i -e SPIDAPTER_EXECUTOR_REPLICAS=4 -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL -e AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY} -e SPIDAPTER_ICEBERG_REGION -e SPIDAPTER_ICEBERG_CATALOG_FROM -e SCHEDULER_STATE_LOCATION"
+          ADAPTER_DOCKER_OPTS="run -i -e SPIDAPTER_EXECUTOR_REPLICAS=${EXECUTOR_REPLICAS} -e SPICEAI_API_KEY -e SPICE_CLOUD_API_URL -e AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY} -e SPIDAPTER_ICEBERG_REGION -e SPIDAPTER_ICEBERG_CATALOG_FROM -e SCHEDULER_STATE_LOCATION"
 
           ADAPTER_DOCKER_OPTS="${ADAPTER_DOCKER_OPTS} -e SPIDAPTER_APP_MEMORY_LIMIT=${SPIDAPTER_APP_MEMORY_LIMIT}"
+          ADAPTER_DOCKER_OPTS="${ADAPTER_DOCKER_OPTS} -e SPIDAPTER_EXECUTOR_MEMORY_LIMIT=${SPIDAPTER_EXECUTOR_MEMORY_LIMIT}"
+
+          # Parse custom image into registry, name, and tag for spidapter.
+          # Expected format: registry/image:tag (e.g. ghcr.io/spiceai/spiceai-dev:spicebench-sf10)
+          # Parses as: registry=ghcr.io, image=spiceai/spiceai-dev, tag=spicebench-sf10
+          if [ -n "${CUSTOM_IMAGE}" ]; then
+            IMAGE_WITH_TAG="${CUSTOM_IMAGE}"
+            if [[ "${IMAGE_WITH_TAG}" == *":"* ]]; then
+              SPIDAPTER_IMAGE_TAG="${IMAGE_WITH_TAG##*:}"
+              IMAGE_WITHOUT_TAG="${IMAGE_WITH_TAG%:*}"
+            else
+              SPIDAPTER_IMAGE_TAG=""
+              IMAGE_WITHOUT_TAG="${IMAGE_WITH_TAG}"
+            fi
+            # Registry is the first path component (hostname), image is the rest
+            SPIDAPTER_IMAGE_REGISTRY="${IMAGE_WITHOUT_TAG%%/*}"
+            SPIDAPTER_IMAGE_NAME="${IMAGE_WITHOUT_TAG#*/}"
+
+            echo "Custom image: registry=${SPIDAPTER_IMAGE_REGISTRY}, name=${SPIDAPTER_IMAGE_NAME}, tag=${SPIDAPTER_IMAGE_TAG}"
+            ADAPTER_DOCKER_OPTS="${ADAPTER_DOCKER_OPTS} -e SPIDAPTER_IMAGE_REGISTRY=${SPIDAPTER_IMAGE_REGISTRY} -e SPIDAPTER_IMAGE_NAME=${SPIDAPTER_IMAGE_NAME}"
+            if [ -n "${SPIDAPTER_IMAGE_TAG}" ]; then
+              ADAPTER_DOCKER_OPTS="${ADAPTER_DOCKER_OPTS} -e SPIDAPTER_IMAGE_TAG=${SPIDAPTER_IMAGE_TAG}"
+            fi
+          fi
 
           if [ "${ENABLE_PVC}" = "true" ]; then
             echo "PVC enabled: app=3GB, executor=2GB"
             ADAPTER_DOCKER_OPTS="${ADAPTER_DOCKER_OPTS} -e SPIDAPTER_APP_STORAGE_SIZE_GB=3 -e SPIDAPTER_EXECUTOR_STORAGE_SIZE_GB=2 -e SPIDAPTER_CAYENNE_DATA_DIR=/data/data -e SPIDAPTER_CAYENNE_METADATA_DIR=/data/metadata"
           fi
 
-          ADAPTER_ARGS="${ADAPTER_DOCKER_OPTS} ghcr.io/spiceai/spidapter:${{ github.event.inputs.spidapter_version || 'latest' }} stdio --verbose --channel nightly"
+          # Use internal channel when a custom image is specified, otherwise nightly.
+          SPIDAPTER_CHANNEL="nightly"
+          if [ -n "${CUSTOM_IMAGE}" ]; then
+            SPIDAPTER_CHANNEL="internal"
+          fi
+
+          ADAPTER_ARGS="${ADAPTER_DOCKER_OPTS} ghcr.io/spiceai/spidapter:${{ github.event.inputs.spidapter_version || 'latest' }} stdio --verbose --channel ${SPIDAPTER_CHANNEL}"
           ADAPTER_ENVS=""
 
           NO_TEARDOWN_ARG=""

--- a/.github/workflows/run_spicebench_debug_spice_cloud.yml
+++ b/.github/workflows/run_spicebench_debug_spice_cloud.yml
@@ -177,6 +177,7 @@ jobs:
           EXECUTOR_REPLICAS: ${{ github.event.inputs.executor_replicas || '4' }}
           SPIDAPTER_APP_MEMORY_LIMIT: ${{ github.event.inputs.app_memory_limit || '16Gi' }}
           SPIDAPTER_EXECUTOR_MEMORY_LIMIT: ${{ github.event.inputs.executor_memory_limit || '16Gi' }}
+          SPIDAPTER_ORGANIZATION_TAG: 'spicehq'
           CUSTOM_IMAGE: ${{ github.event.inputs.custom_image || '' }}
         run: |
           set -euo pipefail
@@ -225,6 +226,7 @@ jobs:
 
           ADAPTER_DOCKER_OPTS="${ADAPTER_DOCKER_OPTS} -e SPIDAPTER_APP_MEMORY_LIMIT=${SPIDAPTER_APP_MEMORY_LIMIT}"
           ADAPTER_DOCKER_OPTS="${ADAPTER_DOCKER_OPTS} -e SPIDAPTER_EXECUTOR_MEMORY_LIMIT=${SPIDAPTER_EXECUTOR_MEMORY_LIMIT}"
+          ADAPTER_DOCKER_OPTS="${ADAPTER_DOCKER_OPTS} -e SPIDAPTER_ORGANIZATION_TAG"
 
           # Parse custom image into registry, name, and tag for spidapter.
           # Expected format: registry/image:tag (e.g. ghcr.io/spiceai/spiceai-dev:spicebench-sf10)

--- a/crates/etl/src/lib.rs
+++ b/crates/etl/src/lib.rs
@@ -830,6 +830,30 @@ async fn write_segments_for_batch(
 ) -> Result<(), String> {
     let table_name_owned = table_name.to_string();
 
+    // Log per-operation row counts for data reconciliation.
+    {
+        let mut insert_rows: usize = 0;
+        let mut update_rows: usize = 0;
+        let mut delete_rows: usize = 0;
+        for seg in &segments {
+            let n = seg.batch.num_rows();
+            match &seg.op {
+                InsertOp::Insert => insert_rows += n,
+                InsertOp::Update { .. } => update_rows += n,
+                InsertOp::Delete { .. } => delete_rows += n,
+            }
+        }
+        tracing::info!(
+            table = %table_name,
+            batch_id,
+            segments = segments.len(),
+            insert_rows,
+            update_rows,
+            delete_rows,
+            "Writing segments for batch",
+        );
+    }
+
     let insert_only = segments
         .iter()
         .all(|segment| matches!(segment.op, InsertOp::Insert));

--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -653,8 +653,48 @@ async fn run_checkpoint_validation(
         return CheckpointValidationResult::TimedOut;
     };
 
+    // Phase 0: validate table row counts first as a fast correctness probe.
+    // Row count queries are cheap and immediately surface data loss/duplication
+    // without waiting for expensive analytical queries to converge.
+    println!("Checkpoint {checkpoint_idx}: validating table row counts before probing queries",);
+    {
+        let mut row_count_ticker = tokio::time::interval(probe_period);
+        let mut row_count_attempt = 0u64;
+        loop {
+            if tokio::time::Instant::now() >= deadline {
+                println!(
+                    "Checkpoint {checkpoint_idx}: row count validation timed out after {} attempts",
+                    row_count_attempt
+                );
+                return CheckpointValidationResult::TimedOut;
+            }
+
+            tokio::select! {
+                biased;
+                _ = signal::ctrl_c() => return CheckpointValidationResult::Interrupted,
+                _ = row_count_ticker.tick() => {}
+            };
+
+            row_count_attempt += 1;
+            if validate_checkpoint_table_row_counts(
+                executor,
+                expected_row_counts,
+                checkpoint_idx,
+                query_catalog_namespace,
+            )
+            .await
+            {
+                break;
+            }
+
+            println!(
+                "Checkpoint {checkpoint_idx}: row count validation attempt {row_count_attempt} failed, retrying",
+            );
+        }
+    }
+
     println!(
-        "Checkpoint {checkpoint_idx}: probing '{}' every {}s",
+        "Checkpoint {checkpoint_idx}: row counts passed, probing '{}' every {}s",
         probe_query.name,
         probe_period.as_secs()
     );
@@ -663,7 +703,7 @@ async fn run_checkpoint_validation(
     let mut probe_count = 0u64;
 
     loop {
-        // Phase 1: probe Q1 until it passes
+        // Phase 1: probe query until it passes
         let e2e_send_time = match probe_until_pass(
             executor,
             probe_query,
@@ -677,7 +717,7 @@ async fn run_checkpoint_validation(
         {
             ProbeOutcome::Passed(send_time) => {
                 println!(
-                    "Checkpoint {checkpoint_idx}: probe query '{}' passed, validating table row counts",
+                    "Checkpoint {checkpoint_idx}: probe query '{}' passed, validating full query set",
                     probe_query.name
                 );
                 send_time
@@ -689,17 +729,6 @@ async fn run_checkpoint_validation(
         // Phase 2: validate the full query set
         if tokio::time::Instant::now() >= deadline {
             return CheckpointValidationResult::TimedOut;
-        }
-
-        if !validate_checkpoint_table_row_counts(
-            executor,
-            expected_row_counts,
-            checkpoint_idx,
-            query_catalog_namespace,
-        )
-        .await
-        {
-            continue;
         }
 
         if validate_full_query_set(


### PR DESCRIPTION
Add a `custom_image` workflow input to `run_spicebench_debug_spice_cloud` that allows specifying a custom runtime container image (e.g. `ghcr.io/spiceai/spiceai-dev:spicebench-sf10`) instead of the default nightly image.

### How it works

When `custom_image` is set, the image reference is parsed into components:
- `ghcr.io/spiceai/spiceai-dev:spicebench-sf10` → `registry=ghcr.io`, `image=spiceai/spiceai-dev`, `tag=spicebench-sf10`

These are passed to spidapter as `SPIDAPTER_IMAGE_REGISTRY`, `SPIDAPTER_IMAGE_NAME`, and `SPIDAPTER_IMAGE_TAG` env vars. The channel is automatically switched from `nightly` to `internal`.

### Other changes
- Added `executor_memory_limit` input (was missing from debug workflow but present in main workflow)

### Depends on
- spiceai/spiceai#9991 — adds `--image-registry`, `--image-name`, `--image-tag` support to spidapter
- spicehq/cloud#4351 (merged) — adds `spiceai/spiceai-dev` to `INTERNAL_RUNTIME_IMAGES`