### PR TITLE
feat(system-adapter-protocol): add optional endpoints field for non-ADBC transports

### DIFF
--- a/crates/system-adapter-protocol/src/lib.rs
+++ b/crates/system-adapter-protocol/src/lib.rs
@@ -81,6 +81,8 @@ limitations under the License.
 //!             driver: AdbcDriver::Flightsql,
 //!             db_kwargs: HashMap::new(),
 //!             catalog_namespace: None,
+//!             read_driver: None,
+//!             endpoints: HashMap::new(),
 //!         })
 //!     }
 //!
@@ -192,6 +194,19 @@ pub struct SetupResponse {
     pub catalog_namespace: Option<String>,
     /// Optional read driver to use for reading data from the benchmark tables.
     pub read_driver: Option<(AdbcDriver, HashMap<String, serde_json::Value>)>,
+    /// Additional non-ADBC transports the SUT exposes, keyed by transport
+    /// identifier. Each value is a free-form kwargs map (mirroring `db_kwargs`
+    /// in shape) whose keys are interpreted by the consumer based on the
+    /// transport identifier. Lets adapters expose endpoints that aren't
+    /// reachable through an ADBC driver (e.g. Spice-specific HTTP APIs)
+    /// without growing the protocol every time a new field is needed.
+    ///
+    /// Well-known transport keys and their kwargs:
+    /// - `spice.http.v1.queries` — Spice's async query API
+    ///   (`POST /v1/queries`). Kwargs: `url` (required), `authorization_header`
+    ///   (optional). Used to benchmark the distributed (Ballista) query path.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub endpoints: HashMap<String, HashMap<String, serde_json::Value>>,
 }
 /// Request to teardown a benchmark run
 ///

--- a/crates/system-adapter-protocol/src/server.rs
+++ b/crates/system-adapter-protocol/src/server.rs
@@ -335,6 +335,8 @@ mod tests {
                 driver: crate::AdbcDriver::Flightsql,
                 db_kwargs: HashMap::new(),
                 catalog_namespace: None,
+                read_driver: None,
+                endpoints: HashMap::new(),
             })
         }
 

--- a/docs/system-adapters.md
+++ b/docs/system-adapters.md
@@ -108,12 +108,38 @@ Returns ADBC connection details for the benchmark run and can optionally provisi
 
 The response tells SpiceBench which ADBC driver to use for query execution. For manually prepared systems, `setup` can simply validate inputs and return the existing driver + connection details without creating any new resources.
 
-| Field               | Required | Description                                                |
-| ------------------- | -------- | ---------------------------------------------------------- |
-| `driver`            | Yes      | ADBC driver name (`flightsql`, `databricks`, `postgresql`) |
-| `db_kwargs`         | Yes      | Driver-specific connection parameters                      |
-| `catalog_namespace` | No       | Catalog/schema path where tables were created              |
-| `read_driver`       | No       | Optional separate driver + kwargs for read-side queries    |
+| Field               | Required | Description                                                                                                                                                            |
+| ------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `driver`            | Yes      | ADBC driver name (`flightsql`, `databricks`, `postgresql`)                                                                                                             |
+| `db_kwargs`         | Yes      | Driver-specific connection parameters                                                                                                                                  |
+| `catalog_namespace` | No       | Catalog/schema path where tables were created                                                                                                                          |
+| `read_driver`       | No       | Optional separate driver + kwargs for read-side queries                                                                                                                |
+| `endpoints`         | No       | Map of additional non-ADBC transports the SUT exposes, keyed by transport identifier. Each value is a free-form kwargs map. Omit when only the ADBC path is available. |
+
+#### `endpoints` (non-ADBC transports)
+
+`endpoints` lets adapters advertise endpoints that aren't reachable through an ADBC driver — for example, Spice's HTTP query APIs — without growing the response shape every time a new field is needed. The outer key identifies the transport; the inner map is interpreted by the consumer based on that key.
+
+```json
+{
+    "result": {
+        "driver": "flightsql",
+        "db_kwargs": { "uri": "grpc://scheduler:50051" },
+        "endpoints": {
+            "spice.http.v1.queries": {
+                "url": "http://scheduler:8090/v1/queries",
+                "authorization_header": "Bearer ..."
+            }
+        }
+    }
+}
+```
+
+Well-known transport keys:
+
+| Key                     | Purpose                                                                                  | Kwargs                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `spice.http.v1.queries` | Spice's async query API (`POST /v1/queries`). Used to benchmark the distributed (Ballista) query path. | `url` (required), `authorization_header` (optional). Additional kwargs may be defined over time without protocol changes. |
 
 ### `teardown`
 

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -2138,6 +2138,7 @@ impl Handler for DatabricksAdapter {
                         AdbcDriver::Postgresql,
                         HashMap::from([("uri".to_string(), Value::String(pg_uri))]),
                     )),
+                    endpoints: HashMap::new(),
                 })
             }
             // For other variants, return a single Databricks ADBC driver.
@@ -2152,6 +2153,7 @@ impl Handler for DatabricksAdapter {
                 ]),
                 catalog_namespace: Some(format!("{}.{}", self.config.catalog, self.config.schema)),
                 read_driver: None,
+                endpoints: HashMap::new(),
             }),
         }
     }


### PR DESCRIPTION
## Summary
- Adds an optional `endpoints: HashMap<String, HashMap<String, serde_json::Value>>` field to `SetupResponse`, mirroring the shape of `db_kwargs`.
- Lets adapters advertise non-ADBC endpoints (e.g. Spice's HTTP query APIs) alongside the existing ADBC `driver` + `db_kwargs`, without protocol churn whenever a new endpoint or kwarg is needed.
- Existing adapters that don't return `endpoints` keep working unchanged (the field is `#[serde(default, skip_serializing_if = "HashMap::is_empty")]`).

## Why
Upcoming testoperator work needs to drive Spice clusters via both Flight SQL (existing path) and HTTP `/v1/queries` (Ballista distributed query). Returning a single ADBC driver isn't enough: testoperator needs the Flight URL **and** the HTTP base URL from the same `setup` response.

We considered piggy-backing the HTTP URL on `db_kwargs` under a `spice.*` namespace, but not all ADBC drivers ignore unknown kwargs — strict drivers would reject them. A dedicated, free-form `endpoints` field is cleaner and keeps non-ADBC info out of the ADBC channel.

Outer key = transport identifier (well-known string, e.g. `spice.http.v1.queries`). Inner kwargs map carries `url`, `authorization_header`, and any future per-transport options.

Drive-by: filled in missing `read_driver: None` in the `TestHandler` and lib.rs doc example so the test build passes (was failing on trunk).

## Test plan
- [x] `cargo test -p system-adapter-protocol --all-features` — passes
- [x] `cargo check --tests --all-features` — passes for the whole workspace
- [x] Databricks adapter still compiles
- [x] Doc example in `docs/system-adapters.md` reflects the new field and documents the `spice.http.v1.queries` convention