### PR TITLE
Fix staging table strategy

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -130,10 +130,13 @@ async fn run_benchmark(
     // primary keys. MERGE INTO handles matching via the ON clause and uses
     // delete+insert execution, which conflicts with Cayenne's automatic
     // on_conflict: Upsert behavior on primary-key tables.
+    // Note: preserve PKs for system adapter setup (e.g. Lakebase synced tables
+    // require primary_key_columns) and only strip them for the ETL pipeline.
     let uses_staging_table = std::env::var("SPICEBENCH_ADBC_UPDATE_STRATEGY")
         .ok()
         .map(|v| v.eq_ignore_ascii_case("staging_table"))
         .unwrap_or(false);
+    let setup_datasets = datasets.clone();
     if uses_staging_table {
         for config in datasets.values_mut() {
             config.primary_key_columns.clear();
@@ -146,7 +149,7 @@ async fn run_benchmark(
             .setup(
                 run_id,
                 setup_metadata.clone(),
-                datasets.clone(),
+                setup_datasets,
                 Some(etl_sink_type),
             )
             .await

--- a/system-adapters/databricks/Cargo.lock
+++ b/system-adapters/databricks/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -1682,7 +1683,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]


### PR DESCRIPTION
## 🗣 Description

Got broken in #243

The staging table strategy strips primary keys from dataset configs to prevent Cayenne's upsert-on-conflict behavior from conflicting with MERGE-based updates. However, the stripping happened before `setup()` was called, so the system adapter also received empty PKs — breaking Lakebase's `create_synced_table` API which requires at least one primary key column.

Fix: clone datasets before stripping so setup gets the original PKs, while the ETL pipeline still gets the stripped version.

Verified in https://github.com/spiceai/spicebench/actions/runs/25971199591