### PR TITLE
fix: prevent SUT metrics scrape from hanging databricks-sql benchmark shutdown

### DIFF
--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -185,6 +185,13 @@ fn spawn_sut_metrics_scraper(
     attributes: Arc<std::sync::RwLock<Vec<KeyValue>>>,
     instruments: SutInstruments,
 ) -> tokio::task::JoinHandle<Option<MetricsResponse>> {
+    // Bound every scrape so a wedged adapter call can neither hold the adapter
+    // lock indefinitely nor stop this task from observing shutdown. A periodic
+    // scrape should be quick; the final scrape may legitimately run a Query
+    // History marker-wait before summing I/O, so it gets a larger budget.
+    const PERIODIC_SCRAPE_TIMEOUT: Duration = Duration::from_secs(180);
+    const FINAL_SCRAPE_TIMEOUT: Duration = Duration::from_secs(780);
+
     tokio::spawn(async move {
         let mut last_response: Option<MetricsResponse> = None;
         let mut prev_disk_read_bytes: Option<u64> = None;
@@ -198,9 +205,13 @@ fn spawn_sut_metrics_scraper(
         loop {
             tokio::select! {
                 _ = ticker.tick() => {
-                    let metrics_result = adapter.lock().await.metrics(run_id, false).await;
+                    let metrics_result = tokio::time::timeout(
+                        PERIODIC_SCRAPE_TIMEOUT,
+                        async { adapter.lock().await.metrics(run_id, false).await },
+                    )
+                    .await;
                     match metrics_result {
-                        Ok(resp) => {
+                        Ok(Ok(resp)) => {
                             let attrs = attributes.read().expect("SUT attributes lock poisoned");
                             log_sut_metrics_snapshot(&resp);
                             record_sut_metrics(
@@ -217,29 +228,52 @@ fn spawn_sut_metrics_scraper(
                             );
                             last_response = Some(resp);
                         }
-                        Err(e) => {
+                        Ok(Err(e)) => {
                             eprintln!("SUT metrics scrape failed: {e}");
+                        }
+                        Err(_) => {
+                            eprintln!(
+                                "SUT metrics scrape timed out after {}s, skipping",
+                                PERIODIC_SCRAPE_TIMEOUT.as_secs()
+                            );
                         }
                     }
                 }
                 () = token.cancelled() => {
-                    // Final scrape before exiting
-                    if let Ok(resp) = adapter.lock().await.metrics(run_id, true).await {
-                        let attrs = attributes.read().expect("SUT attributes lock poisoned");
-                        log_sut_metrics_snapshot(&resp);
-                        record_sut_metrics(
-                            &resp,
-                            &instruments,
-                            &attrs,
-                            &mut prev_cpu_usage_seconds,
-                            &mut prev_disk_read_bytes,
-                            &mut prev_disk_write_bytes,
-                            &mut prev_disk_read_iops,
-                            &mut prev_disk_write_iops,
-                            &mut prev_rows_ingested,
-                            &mut last_scrape_time,
-                        );
-                        last_response = Some(resp);
+                    // Final scrape before exiting. Bounded so cancellation can
+                    // never leave this task (and the shutdown join) hanging.
+                    let final_result = tokio::time::timeout(
+                        FINAL_SCRAPE_TIMEOUT,
+                        async { adapter.lock().await.metrics(run_id, true).await },
+                    )
+                    .await;
+                    match final_result {
+                        Ok(Ok(resp)) => {
+                            let attrs = attributes.read().expect("SUT attributes lock poisoned");
+                            log_sut_metrics_snapshot(&resp);
+                            record_sut_metrics(
+                                &resp,
+                                &instruments,
+                                &attrs,
+                                &mut prev_cpu_usage_seconds,
+                                &mut prev_disk_read_bytes,
+                                &mut prev_disk_write_bytes,
+                                &mut prev_disk_read_iops,
+                                &mut prev_disk_write_iops,
+                                &mut prev_rows_ingested,
+                                &mut last_scrape_time,
+                            );
+                            last_response = Some(resp);
+                        }
+                        Ok(Err(e)) => {
+                            eprintln!("Final SUT metrics scrape failed: {e}");
+                        }
+                        Err(_) => {
+                            eprintln!(
+                                "Final SUT metrics scrape timed out after {}s, abandoning",
+                                FINAL_SCRAPE_TIMEOUT.as_secs()
+                            );
+                        }
                     }
                     break;
                 }
@@ -1227,18 +1261,33 @@ pub(crate) async fn run(
             .expect("SUT attributes lock poisoned")
             .push(KeyValue::new("outcome", outcome.as_str()));
     }
-    // Stop SUT metrics scraper and flush its pipeline
+    // Stop SUT metrics scraper and flush its pipeline. The scraper runs a final
+    // (bounded) scrape on cancellation, but shutdown must never hang waiting for
+    // it: if the join overruns, abort the task and continue without final SUT
+    // metrics rather than wedging the whole run.
     sut_scraper_token.cancel();
-    if let Some(handle) = sut_scraper_handle
-        && let Ok(Some(last_sut_metrics)) = handle.await
-    {
-        println!(
-            "Final SUT metrics: cpu_sec={:?}, mem={:?}B, ingested_rows={:?}, ingested_bytes={:?}",
-            last_sut_metrics.resource.cpu_usage_percent,
-            last_sut_metrics.resource.memory_usage_bytes,
-            last_sut_metrics.ingestion.rows_ingested,
-            last_sut_metrics.ingestion.bytes_ingested,
-        );
+    if let Some(mut handle) = sut_scraper_handle {
+        const SCRAPER_JOIN_TIMEOUT: Duration = Duration::from_secs(840);
+        match tokio::time::timeout(SCRAPER_JOIN_TIMEOUT, &mut handle).await {
+            Ok(Ok(Some(last_sut_metrics))) => {
+                println!(
+                    "Final SUT metrics: cpu_sec={:?}, mem={:?}B, ingested_rows={:?}, ingested_bytes={:?}",
+                    last_sut_metrics.resource.cpu_usage_percent,
+                    last_sut_metrics.resource.memory_usage_bytes,
+                    last_sut_metrics.ingestion.rows_ingested,
+                    last_sut_metrics.ingestion.bytes_ingested,
+                );
+            }
+            Ok(Ok(None)) => {}
+            Ok(Err(e)) => eprintln!("SUT metrics scraper task failed: {e}"),
+            Err(_) => {
+                eprintln!(
+                    "SUT metrics scraper did not finish within {}s; aborting it and continuing shutdown",
+                    SCRAPER_JOIN_TIMEOUT.as_secs()
+                );
+                handle.abort();
+            }
+        }
     }
     if let Some(pipeline) = sut_pipeline {
         pipeline.shutdown();

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -1002,10 +1002,19 @@ impl DatabricksAdapter {
     /// REST path: paginate through `/api/2.0/sql/history/queries` and sum
     /// per-query `metrics.read_bytes` and `metrics.write_remote_bytes + spill_to_disk_bytes`.
     async fn sum_query_history_io_rest(&self, start_time_ms: u64) -> Result<(u64, u64)> {
+        // Hard bounds on pagination. This sum is best-effort telemetry, so we
+        // would rather degrade to a partial/failed scrape than walk the API
+        // forever: a missing/empty `next_page_token` while `has_next_page` is
+        // true, or re-sending `filter_by` on continuation pages, can otherwise
+        // make the API restart from page one and never terminate.
+        const IO_SUM_DEADLINE: Duration = Duration::from_secs(120);
+        const MAX_PAGES: usize = 100;
+
         let history_url = format!(
             "https://{}/api/2.0/sql/history/queries",
             self.config.endpoint
         );
+        let deadline = std::time::Instant::now() + IO_SUM_DEADLINE;
 
         let mut total_read_bytes: u64 = 0;
         let mut total_read_remote_bytes: u64 = 0;
@@ -1013,23 +1022,41 @@ impl DatabricksAdapter {
         let mut total_write_remote_bytes: u64 = 0;
         let mut total_spill_to_disk_bytes: u64 = 0;
         let mut page_token: Option<String> = None;
+        let mut pages: usize = 0;
 
         loop {
-            let mut filter = json!({
-                "filter_by": {
-                    "warehouse_ids": [self.config.warehouse_id],
-                    "query_start_time_range": {
-                        "start_time_ms": start_time_ms
-                    },
-                    "statuses": ["FINISHED"]
-                },
-                "include_metrics": true,
-                "max_results": 100
-            });
-
-            if let Some(ref token) = page_token {
-                filter["page_token"] = json!(token);
+            if std::time::Instant::now() > deadline {
+                return Err(anyhow!(
+                    "Timed out ({}s) summing Query History I/O after {pages} page(s)",
+                    IO_SUM_DEADLINE.as_secs()
+                ));
             }
+            if pages >= MAX_PAGES {
+                return Err(anyhow!(
+                    "Query History I/O sum exceeded {MAX_PAGES} pages; aborting pagination"
+                ));
+            }
+            pages += 1;
+
+            // Build the request body. On the first page we send the full
+            // filter; on continuation pages the Query History API derives the
+            // filter from `page_token`, so we send *only* the token. Re-sending
+            // `filter_by` alongside `page_token` can reset pagination back to
+            // page one, causing an unbounded loop.
+            let filter = match page_token {
+                Some(ref token) => json!({ "page_token": token }),
+                None => json!({
+                    "filter_by": {
+                        "warehouse_ids": [self.config.warehouse_id],
+                        "query_start_time_range": {
+                            "start_time_ms": start_time_ms
+                        },
+                        "statuses": ["FINISHED"]
+                    },
+                    "include_metrics": true,
+                    "max_results": 100
+                }),
+            };
 
             let response = self
                 .client
@@ -1057,10 +1084,12 @@ impl DatabricksAdapter {
                 }
             }
 
-            if body.has_next_page {
-                page_token = body.next_page_token;
-            } else {
-                break;
+            // Only continue when the API both reports another page *and* hands
+            // back a token to fetch it. `has_next_page == true` with no token
+            // would otherwise reset us to page one and loop forever.
+            match (body.has_next_page, body.next_page_token) {
+                (true, Some(token)) => page_token = Some(token),
+                _ => break,
             }
         }
 


### PR DESCRIPTION
## Problem

A `databricks-sql` benchmark run hung in post-benchmark teardown and had to be cancelled after ~10 min ([run 26725983531](https://github.com/spiceai/spicebench/actions/runs/26725983531/job/78761184843)). The benchmark itself finished fine — ETL loaded, checkpoint converged (2.7s E2E), and both workers exited at `22:19:04` — but the process never reached `Benchmark completed` and was force-killed, leaving an orphaned `databricks-system-adapter`.

## Root cause

The SUT metrics scraper's very first scrape (5s interval) entered the adapter's `metrics()`, printed `warehouse_info`, then called `sum_query_history_io_rest` and **never returned** — no completion log, no error, for the entire ~13 min.

That function paginated `/api/2.0/sql/history/queries` in a loop with **no overall deadline and no page cap** (the 60s per-request reqwest timeout only bounds single calls). It re-sent `filter_by` on continuation requests and, on `has_next_page == true` with a missing `next_page_token`, cleared the token and restarted from page one — either of which can loop forever.

Because the scraper holds the adapter mutex across the `metrics().await` and was stuck inside that branch, it never observed `sut_scraper_token.cancel()`, so shutdown's unconditional `handle.await` blocked forever. (Query workers use the ADBC read pool, not the adapter lock, which is why the benchmark itself completed normally.)

## Fixes

**1. `databricks-adapter`: bound the pagination (direct cause)**
- 120s deadline + 100-page cap on `sum_query_history_io_rest`
- send only `page_token` on continuation requests (not the full `filter_by`)
- stop cleanly when `has_next_page` is true but no token is returned
- a bounded failure returns `Err`, which the caller already treats as best-effort telemetry

**2. `spicebench`: never let the scraper hang shutdown (defense-in-depth)**
- wrap each scrape in a `tokio::time::timeout` (180s periodic, 780s final) so a wedged adapter call can neither hold the adapter lock indefinitely nor stop the task from observing cancellation
- bound the shutdown join with an 840s timeout that `abort()`s the scraper task if it overruns, so the run can always exit instead of blocking on `handle.await`

## Verification
- `cargo check` + `cargo clippy` clean on both `databricks-system-adapter` and `spicebench` (no new warnings)

Split into two commits (separate cargo workspaces) for easier review.
