### PR TITLE
fix(databricks-adapter): cap periodic SUT metrics scrape at 500ms so it can't block ingest

### DIFF
--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -2360,22 +2360,50 @@ impl Handler for DatabricksAdapter {
                 }
 
                 // Sum read_bytes and (write_remote_bytes + spill_to_disk_bytes) from all
-                // queries since the run started. On periodic scrapes this is best-effort
-                // (Query History has ~5 min lag). On final scrape the marker wait above
-                // ensures completeness.
-                match self.sum_query_history_io(started_at_ms).await {
-                    Ok((total_read, total_write)) => {
+                // queries since the run started. This walks the Query History API and can
+                // take many seconds on a warehouse with deep history.
+                //
+                // The metrics scrape shares the adapter's stdio connection (and its lock)
+                // with the benchmark's ingest path, so a slow scrape blocks ingestion.
+                // Metrics are best-effort observability and must never perturb the
+                // benchmark, so on periodic scrapes we bound this walk to 500ms and skip
+                // it if it overruns — ingest can then resume immediately. Cancelling here
+                // only aborts the adapter's own outbound HTTP request (safe), unlike a
+                // client-side timeout which would cancel the stdio read mid-response and
+                // desync the protocol. The final scrape runs at shutdown (no ingest
+                // contention) and is left unbounded for accurate totals.
+                let io_sum = if final_scrape {
+                    Some(self.sum_query_history_io(started_at_ms).await)
+                } else {
+                    match tokio::time::timeout(
+                        Duration::from_millis(500),
+                        self.sum_query_history_io(started_at_ms),
+                    )
+                    .await
+                    {
+                        Ok(result) => Some(result),
+                        Err(_) => {
+                            eprintln!(
+                                "[databricks-adapter] periodic query history I/O sum exceeded 500ms budget; skipping so ingest is not blocked"
+                            );
+                            None
+                        }
+                    }
+                };
+                match io_sum {
+                    Some(Ok((total_read, total_write))) => {
                         eprintln!(
                             "[databricks-adapter] query history totals: read_bytes={total_read} write_bytes={total_write}"
                         );
                         resource.disk_read_bytes = Some(total_read);
                         resource.disk_write_bytes = Some(total_write);
                     }
-                    Err(e) => {
+                    Some(Err(e)) => {
                         eprintln!(
                             "[databricks-adapter] warning: query history I/O sum failed: {e}"
                         );
                     }
+                    None => {}
                 }
 
                 Ok(MetricsResponse {


### PR DESCRIPTION
## Problem

The SUT metrics scraper shares the system adapter's **stdio connection (and its mutex)** with the benchmark's ingest path. On a SQL warehouse with deep Query History, the periodic Query-History I/O sum (`sum_query_history_io`) takes ~10s, and it holds that lock the whole time — so `changes`-mode ingestion (whose `staging_table` `create_staging_table` needs the same connection) stalls behind it.

Observed on run [26727538702](https://github.com/spiceai/spicebench/actions/runs/26727538702): the first ETL step sat at `batches=0/114` for ~10 min while the scraper repeatedly walked 100+ pages of Query History (the #252 cap aborted it 41×). Metrics collection is observability and must never perturb the benchmark it measures.

## Fix

Bound the Query-History I/O walk to **500ms on periodic scrapes** and skip it if it overruns, so ingest resumes immediately. The **final** scrape (run at shutdown, when there's no ingest contention) is left unbounded for accurate I/O totals.

```rust
let io_sum = if final_scrape {
    Some(self.sum_query_history_io(started_at_ms).await)
} else {
    match tokio::time::timeout(Duration::from_millis(500),
                               self.sum_query_history_io(started_at_ms)).await {
        Ok(result) => Some(result),
        Err(_) => { /* skip so ingest is not blocked */ None }
    }
};
```

### Why the timeout is adapter-side, not on the scraper

A client-side `tokio::timeout` on the scraper would be **unsafe**: cancelling the metrics RPC mid-`read_line` leaves the adapter's response in the stdio pipe, and the ETL's next request reads that stale response → permanent protocol desync. The adapter-side timeout instead cancels the adapter's own **outbound HTTP request** to Databricks (cancellation-safe) and bounds how long the handler holds the stdio lock.

## Trade-offs

- `warehouse_info` (active sessions / clusters) still runs unbounded before the walk, but it's a single fast GET — periodic lock-hold is now ≈ that + ≤500ms instead of ~10s.
- On a deep-history warehouse the 500ms budget will usually trip, so periodic scrapes stop recording `disk_read/write_bytes` (only the final scrape will). Those mid-run values were laggy (~5 min) anyway. Preserving live disk-byte sampling would require giving the scraper its own adapter connection (deferred — not feasible in the current single-connection design).

Follow-up to #252.
