### PR TITLE
fix: scope SUT Query-History sum to the current run + back off slow scrapes

### DIFF
--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -191,6 +191,12 @@ fn spawn_sut_metrics_scraper(
     // History marker-wait before summing I/O, so it gets a larger budget.
     const PERIODIC_SCRAPE_TIMEOUT: Duration = Duration::from_secs(180);
     const FINAL_SCRAPE_TIMEOUT: Duration = Duration::from_secs(780);
+    // A periodic scrape slower than this holds the shared adapter connection long
+    // enough to perturb ingest; treat it as "slow" and back off (below).
+    const SLOW_SCRAPE_THRESHOLD: Duration = Duration::from_millis(500);
+    // Cap the Fibonacci backoff so SUT metrics never go dark for more than this
+    // many ticks between samples.
+    const MAX_BACKOFF_TICKS: u64 = 13;
 
     tokio::spawn(async move {
         let mut last_response: Option<MetricsResponse> = None;
@@ -202,9 +208,21 @@ fn spawn_sut_metrics_scraper(
         let mut prev_rows_ingested: Option<u64> = None;
         let mut last_scrape_time: Option<std::time::Instant> = None;
         let mut ticker = tokio::time::interval(interval);
+        // Fibonacci backoff state: after a slow scrape, skip an increasing number
+        // of ticks (fib_a) before scraping again; a fast scrape resets it.
+        let mut fib_a: u64 = 1;
+        let mut fib_b: u64 = 1;
+        let mut skip_remaining: u64 = 0;
         loop {
             tokio::select! {
                 _ = ticker.tick() => {
+                    if skip_remaining > 0 {
+                        // Backing off after a slow scrape — skip this tick so
+                        // metrics collection stops adding latency to the run.
+                        skip_remaining -= 1;
+                        continue;
+                    }
+                    let scrape_started = std::time::Instant::now();
                     let metrics_result = tokio::time::timeout(
                         PERIODIC_SCRAPE_TIMEOUT,
                         async { adapter.lock().await.metrics(run_id, false).await },
@@ -237,6 +255,19 @@ fn spawn_sut_metrics_scraper(
                                 PERIODIC_SCRAPE_TIMEOUT.as_secs()
                             );
                         }
+                    }
+                    // A slow scrape holds the adapter connection the whole time,
+                    // adding latency to ingest. Skip an increasing (Fibonacci)
+                    // number of subsequent ticks before scraping again; a fast
+                    // scrape resets the backoff.
+                    if scrape_started.elapsed() > SLOW_SCRAPE_THRESHOLD {
+                        skip_remaining = fib_a;
+                        let next = fib_a.saturating_add(fib_b).min(MAX_BACKOFF_TICKS);
+                        fib_a = fib_b;
+                        fib_b = next;
+                    } else {
+                        fib_a = 1;
+                        fib_b = 1;
                     }
                 }
                 () = token.cancelled() => {

--- a/system-adapters/databricks/src/main.rs
+++ b/system-adapters/databricks/src/main.rs
@@ -1016,6 +1016,15 @@ impl DatabricksAdapter {
         );
         let deadline = std::time::Instant::now() + IO_SUM_DEADLINE;
 
+        // Upper bound for the Query History window. Queries can't start in the
+        // future, so [start_time_ms, now] scopes the sum to this run on this
+        // warehouse. A start-only range is not honored by the API (it returns the
+        // warehouse's entire history), so the range must have both bounds.
+        let end_time_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
         let mut total_read_bytes: u64 = 0;
         let mut total_read_remote_bytes: u64 = 0;
         let mut total_read_cache_bytes: u64 = 0;
@@ -1049,7 +1058,8 @@ impl DatabricksAdapter {
                     "filter_by": {
                         "warehouse_ids": [self.config.warehouse_id],
                         "query_start_time_range": {
-                            "start_time_ms": start_time_ms
+                            "start_time_ms": start_time_ms,
+                            "end_time_ms": end_time_ms
                         },
                         "statuses": ["FINISHED"]
                     },


### PR DESCRIPTION
## Background

Follow-up to #252 and #253. Those bounded the SUT metrics scrape (page cap, then a 500ms budget) so it couldn't hang or badly stall ingest — but they treated the symptom. This PR fixes the root cause and removes the residual per-tick overhead.

## 1. Scope the Query-History I/O sum to the run (the real fix)

`sum_query_history_io` filtered only on `query_start_time_range.start_time_ms` (no `end_time_ms`). A start-only range **is not honored** by the Query History API, so the query returned the warehouse's *entire* history — every prior and concurrent run — and walked 100+ pages within seconds of a run starting (this is also what made the original run hang).

Adding `end_time_ms = now` makes the range complete, scoping the sum to `[run_start, now]` on this warehouse. This:
- collapses the walk from 100+ pages to a handful (so the 500ms budget rarely trips and the page cap is essentially never hit), and
- makes the disk-I/O **totals correct** — previously they summed bytes across the whole warehouse, not just this run.

## 2. Fibonacci backoff for slow scrapes (belt-and-suspenders)

The scraper shares the adapter's stdio connection with the ingest path, so even a 500ms-capped scrape adds latency every 5s tick. If a periodic scrape exceeds 500ms, the scraper now skips an increasing (Fibonacci: 1, 1, 2, 3, 5, 8, 13 — capped) number of subsequent ticks before scraping again; a fast scrape resets the backoff. With #1 in place scrapes should be fast and this rarely engages, but it bounds the cumulative cost if a scrape is slow for any reason.

## Notes
- The 500ms budget (#253) and page cap (#252) stay as backstops.
- `warehouse_info` remains a quick unbounded GET before the (now-scoped) walk.

Verified: `cargo check` + `cargo clippy` clean on both `databricks-system-adapter` and `spicebench` (no new warnings).
