### PR TITLE
fix(ci): set SYSTEM_ADAPTER in run_spicebench.yml so SUT metrics are labeled by name

### DIFF
--- a/.github/workflows/run_spicebench.yml
+++ b/.github/workflows/run_spicebench.yml
@@ -43,6 +43,9 @@ on:
 env:
   SCENARIO: ${{ github.event.inputs.scenario || 'tpch' }}
   SYSTEM_UNDER_TEST: ${{ github.event.inputs.system_under_test || 'spice_cloud' }}
+  # Label benchmark metrics (adapter_name) by the actual SUT. Without this,
+  # spicebench falls back to the --system-adapter-name default ("system_adapter").
+  SYSTEM_ADAPTER: ${{ github.event.inputs.system_under_test || 'spice_cloud' }}
   ETL_TYPE: ${{ github.event.inputs.etl_type || 'changes' }}
   SCALE_FACTOR: ${{ github.event.inputs.scale_factor || '1' }}
 


### PR DESCRIPTION
## Problem

Benchmark metrics are tagged with the `adapter_name` attribute, which spicebench sources from `--system-adapter-name` / the `SYSTEM_ADAPTER` env (`src/args/mod.rs`), defaulting to the literal `"system_adapter"`. The dashboards group the per-SUT series by this attribute.

The debug workflows (`run_spicebench_debug_spice_cloud.yml`, `run_spicebench_debug_streaming.yml`) already set `SYSTEM_ADAPTER`, but the production `run_spicebench.yml` only set `SYSTEM_UNDER_TEST`. As a result, any SUT run through the production workflow (e.g. `databricks-sql`) emitted its benchmark metrics under the generic `system_adapter` label instead of its real name — showing up as an orphaned `system_adapter` series on the dashboards.

## Fix

Set `SYSTEM_ADAPTER` from the `system_under_test` input in `run_spicebench.yml`, mirroring the debug workflows. Metric-label only; no behavioral change to the benchmark. Effective on the next run (no rebuild needed).