### PR TITLE
Fix e2e latency metric: add per-checkpoint gauge for exact percentiles

### DIFF
--- a/dashboards/spicebench-benchmarks.grafana.json
+++ b/dashboards/spicebench-benchmarks.grafana.json
@@ -188,7 +188,7 @@
               }
             ]
           },
-          "unit": "ops"
+          "unit": "QPH"
         },
         "overrides": []
       },
@@ -218,11 +218,11 @@
             "type": "influxdb",
             "uid": "1eox324"
           },
-          "query": "from(bucket: \"benchmarks-telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"queries_per_sec\")\n  |> filter(fn: (r) => exists r[\"adapter_name\"])\n  |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n  |> filter(fn: (r) => \"${outcome}\" == \"All\" or r[\"outcome\"] == \"${outcome}\")\n  |> filter(fn: (r) => \"${etl_type}\" == \"All\" or r[\"etl_type\"] == \"${etl_type}\")\n  |> map(fn: (r) => ({\n    r with\n      legend: r[\"adapter_name\"] + \" - \" + r[\"scenario\"]\n    }))\n  |> group(columns: [\"legend\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"legend\"])",
+          "query": "from(bucket: \"benchmarks-telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"queries_per_sec\")\n  |> filter(fn: (r) => exists r[\"adapter_name\"])\n  |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n  |> filter(fn: (r) => \"${outcome}\" == \"All\" or r[\"outcome\"] == \"${outcome}\")\n  |> filter(fn: (r) => \"${etl_type}\" == \"All\" or r[\"etl_type\"] == \"${etl_type}\")\n  |> map(fn: (r) => ({\n    r with\n      _value: r._value * 3600.0,\n      legend: r[\"adapter_name\"] + \" - \" + r[\"scenario\"]\n    }))\n  |> group(columns: [\"legend\"])\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"legend\"])",
           "refId": "A"
         }
       ],
-      "title": "Throughput (queries/sec)",
+      "title": "Throughput (QPH)",
       "type": "timeseries"
     },
     {
@@ -313,7 +313,7 @@
             "type": "influxdb",
             "uid": "1eox324"
           },
-          "query": "from(bucket: \"benchmarks-telemetry\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n  |> filter(fn: (r) => r[\"_measurement\"] == \"e2e_latency_ms\")\n  |> filter(fn: (r) => exists r[\"adapter_name\"])\n  |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n  |> filter(fn: (r) => \"${outcome}\" == \"All\" or r[\"outcome\"] == \"${outcome}\")\n  |> filter(fn: (r) => \"${etl_type}\" == \"All\" or r[\"etl_type\"] == \"${etl_type}\")\n  |> toFloat()\n  |> map(fn: (r) => ({\n    r with\n      legend: r[\"adapter_name\"] + \" - \" + r[\"scenario\"]\n    }))\n  |> group(columns: [\"legend\"])\n  |> window(every: 5m)\n  |> quantile(q: 0.99, method: \"estimate_tdigest\")\n  |> duplicate(column: \"_stop\", as: \"_time\")\n  |> window(every: inf)\n  |> sort(columns: [\"_time\"])\n  |> keep(columns: [\"_time\", \"_value\", \"legend\"])",
+          "query": "old = from(bucket: \"benchmarks-telemetry\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n    |> filter(fn: (r) => r[\"_measurement\"] == \"e2e_latency_ms\")\n    |> filter(fn: (r) => exists r[\"adapter_name\"])\n    |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n    |> filter(fn: (r) => \"${outcome}\" == \"All\" or r[\"outcome\"] == \"${outcome}\")\n    |> filter(fn: (r) => \"${etl_type}\" == \"All\" or r[\"etl_type\"] == \"${etl_type}\")\n    |> toFloat()\n    |> map(fn: (r) => ({ r with legend: r[\"adapter_name\"] + \" - \" + r[\"scenario\"] }))\n    |> group(columns: [\"legend\"])\n    |> window(every: 5m)\n    |> quantile(q: 0.99, method: \"estimate_tdigest\")\n    |> duplicate(column: \"_stop\", as: \"_time\")\n    |> window(every: inf)\n    |> keep(columns: [\"_time\", \"_value\", \"legend\"])\n    |> group(columns: [\"legend\"])\n\n  new = from(bucket: \"benchmarks-telemetry\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n    |> filter(fn: (r) => r[\"_measurement\"] == \"e2e_latency_gauge_ms\")\n    |> filter(fn: (r) => r[\"_field\"] == \"gauge\")          // single value field — no bucket/count/sum grab-bag\n    |> filter(fn: (r) => exists r[\"adapter_name\"])\n    |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n    |> filter(fn: (r) => \"${outcome}\" == \"All\" or r[\"outcome\"] == \"${outcome}\")\n    |> filter(fn: (r) => \"${etl_type}\" == \"All\" or r[\"etl_type\"] == \"${etl_type}\")\n    |> toFloat()\n    |> map(fn: (r) => ({ r with legend: r[\"adapter_name\"] + \" - \" + r[\"scenario\"] }))\n    |> group(columns: [\"legend\"])\n    |> window(every: 5m)\n    |> tail(n: 1)\n    |> duplicate(column: \"_stop\", as: \"_time\")\n    |> window(every: inf)\n    |> keep(columns: [\"_time\", \"_value\", \"legend\"])\n    |> group(columns: [\"legend\"])\n\n  union(tables: [old, new])\n    |> group(columns: [\"legend\"])\n    |> sort(columns: [\"_time\"])\n    |> keep(columns: [\"_time\", \"_value\", \"legend\"])",
           "refId": "A"
         }
       ],
@@ -2074,7 +2074,7 @@
             "type": "influxdb",
             "uid": "1eox324"
           },
-          "query": "qualifying_run_ids = from(bucket: \"benchmarks-telemetry\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n    |> filter(fn: (r) => exists r[\"run_id\"])\n    |> filter(fn: (r) => \"${outcome}\" == \"All\" or (exists r[\"outcome\"] and r[\"outcome\"] == \"${outcome}\"))\n    |> filter(fn: (r) => \"${etl_type}\" == \"All\" or (exists r[\"etl_type\"] and r[\"etl_type\"] == \"${etl_type}\"))\n    |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n    |> keep(columns: [\"run_id\"])\n    |> group()\n    |> distinct(column: \"run_id\")\n    |> findColumn(fn: (key) => true, column: \"_value\")\n\n  from(bucket: \"benchmarks-telemetry\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n    |> filter(fn: (r) => r[\"_measurement\"] == \"sut_cdc_rows_applied\")\n    |> filter(fn: (r) => exists r[\"adapter_name\"])\n    |> filter(fn: (r) => contains(value: r[\"run_id\"], set: qualifying_run_ids))\n    |> group(columns: [\"run_id\", \"adapter_name\", \"scenario\", \"table\"])\n    |> aggregateWindow(every: 30s, fn: last, createEmpty: false)\n    |> derivative(unit: 1s, nonNegative: true, columns: [\"_value\"])\n    |> group(columns: [\"run_id\", \"adapter_name\", \"scenario\"])\n    |> aggregateWindow(every: 30s, fn: sum, createEmpty: false)\n    |> map(fn: (r) => ({ r with legend: r[\"adapter_name\"] + \" - \" + r[\"scenario\"] }))\n    |> group(columns: [\"legend\"])\n    |> sort(columns: [\"_time\"])\n    |> keep(columns: [\"_time\", \"_value\", \"legend\"])",
+          "query": "qualifying_run_ids = from(bucket: \"benchmarks-telemetry\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n    |> filter(fn: (r) => exists r[\"run_id\"])\n    |> filter(fn: (r) => \"${outcome}\" == \"All\" or (exists r[\"outcome\"] and r[\"outcome\"] == \"${outcome}\"))\n    |> filter(fn: (r) => \"${etl_type}\" == \"All\" or (exists r[\"etl_type\"] and r[\"etl_type\"] == \"${etl_type}\"))\n    |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n    |> keep(columns: [\"run_id\"])\n    |> group()\n    |> distinct(column: \"run_id\")\n    |> findColumn(fn: (key) => true, column: \"_value\")\n\n  from(bucket: \"benchmarks-telemetry\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n    |> filter(fn: (r) => r[\"_measurement\"] == \"sut_cdc_rows_applied\")\n    |> filter(fn: (r) => exists r[\"adapter_name\"])\n    |> filter(fn: (r) => contains(value: r[\"run_id\"], set: qualifying_run_ids))\n    |> group(columns: [\"run_id\", \"adapter_name\", \"scenario\", \"table\"])\n    |> aggregateWindow(every: 30s, fn: last, createEmpty: false)\n    |> derivative(unit: 1s, nonNegative: true, columns: [\"_value\"])\n    |> group(columns: [\"run_id\", \"adapter_name\", \"scenario\"])\n    |> aggregateWindow(every: 30s, fn: sum, createEmpty: false)\n    |> map(fn: (r) => ({ r with legend: r[\"adapter_name\"] + \" - \" + r[\"scenario\"] + \" - \" + r[\"run_id\"]}))\n    |> group(columns: [\"legend\"])\n    |> sort(columns: [\"_time\"])\n    |> keep(columns: [\"_time\", \"_value\", \"legend\"])",
           "refId": "A"
         }
       ],
@@ -2170,7 +2170,7 @@
             "type": "influxdb",
             "uid": "1eox324"
           },
-          "query": "qualifying_run_ids = from(bucket: \"benchmarks-telemetry\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n    |> filter(fn: (r) => exists r[\"run_id\"])\n    |> filter(fn: (r) => \"${outcome}\" == \"All\" or (exists r[\"outcome\"] and r[\"outcome\"] == \"${outcome}\"))\n    |> filter(fn: (r) => \"${etl_type}\" == \"All\" or (exists r[\"etl_type\"] and r[\"etl_type\"] == \"${etl_type}\"))\n    |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n    |> keep(columns: [\"run_id\"])\n    |> group()\n    |> distinct(column: \"run_id\")\n    |> findColumn(fn: (key) => true, column: \"_value\")\n\n  total = (m) =>\n    from(bucket: \"benchmarks-telemetry\")\n      |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n      |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n      |> filter(fn: (r) => r[\"_measurement\"] == m)\n      |> filter(fn: (r) => contains(value: r[\"run_id\"], set: qualifying_run_ids))\n      |> group(columns: [\"run_id\", \"adapter_name\", \"scenario\", \"table\"])\n      |> aggregateWindow(every: 30s, fn: last, createEmpty: false)   // cumulative per table\n      |> group(columns: [\"run_id\", \"adapter_name\", \"scenario\"])\n      |> aggregateWindow(every: 30s, fn: sum, createEmpty: false)    // total cumulative across tables\n\n  wait  = total(m: \"sut_cdc_source_wait_ms\")\n  apply = total(m: \"sut_cdc_apply_ms\")\n\n  join(tables: {wait: wait, apply: apply}, on: [\"_time\", \"run_id\", \"adapter_name\", \"scenario\"])\n    |> map(fn: (r) => ({ r with\n        _value: if (r._value_wait + r._value_apply) > 0.0 then 100.0 * r._value_wait / (r._value_wait + r._value_apply) else 0.0,\n        legend: r.adapter_name + \" - \" + r.scenario + \" - \"\n    }))\n    |> group(columns: [\"legend\"])\n    |> sort(columns: [\"_time\"])\n    |> keep(columns: [\"_time\", \"_value\", \"legend\"])",
+          "query": "qualifying_run_ids = from(bucket: \"benchmarks-telemetry\")\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n    |> filter(fn: (r) => exists r[\"run_id\"])\n    |> filter(fn: (r) => \"${outcome}\" == \"All\" or (exists r[\"outcome\"] and r[\"outcome\"] == \"${outcome}\"))\n    |> filter(fn: (r) => \"${etl_type}\" == \"All\" or (exists r[\"etl_type\"] and r[\"etl_type\"] == \"${etl_type}\"))\n    |> filter(fn: (r) => r[\"scale_factor\"] =~ /^${scale_factor:regex}$/)\n    |> keep(columns: [\"run_id\"])\n    |> group()\n    |> distinct(column: \"run_id\")\n    |> findColumn(fn: (key) => true, column: \"_value\")\n\n  total = (m) =>\n    from(bucket: \"benchmarks-telemetry\")\n      |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n      |> filter(fn: (r) => r[\"type\"] == \"spicebench\")\n      |> filter(fn: (r) => r[\"_measurement\"] == m)\n      |> filter(fn: (r) => contains(value: r[\"run_id\"], set: qualifying_run_ids))\n      |> group(columns: [\"run_id\", \"adapter_name\", \"scenario\", \"table\"])\n      |> aggregateWindow(every: 30s, fn: last, createEmpty: false)   // cumulative per table\n      |> group(columns: [\"run_id\", \"adapter_name\", \"scenario\"])\n      |> aggregateWindow(every: 30s, fn: sum, createEmpty: false)    // total cumulative across tables\n\n  wait  = total(m: \"sut_cdc_source_wait_ms\")\n  apply = total(m: \"sut_cdc_apply_ms\")\n\n  join(tables: {wait: wait, apply: apply}, on: [\"_time\", \"run_id\", \"adapter_name\", \"scenario\"])\n    |> map(fn: (r) => ({ r with\n        _value: if (r._value_wait + r._value_apply) > 0.0 then 100.0 * r._value_wait / (r._value_wait + r._value_apply) else 0.0,\n        legend: r.adapter_name + \" - \" + r.scenario + \" - \" + r.run_id\n    }))\n    |> group(columns: [\"legend\"])\n    |> sort(columns: [\"_time\"])\n    |> keep(columns: [\"_time\", \"_value\", \"legend\"])",
           "refId": "A"
         }
       ],
@@ -2179,7 +2179,6 @@
     }
   ],
   "preload": false,
-  "refresh": "5s",
   "schemaVersion": 40,
   "tags": [],
   "templating": {
@@ -2306,6 +2305,6 @@
   "timezone": "browser",
   "title": "SpiceBench benchmark insights",
   "uid": "afdqis05ydnuod",
-  "version": 6,
+  "version": 9,
   "weekStart": ""
 }

--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -1352,8 +1352,6 @@ pub(crate) async fn run(
 
     // Record deferred metrics now that outcome is available.
     for (checkpoint_idx, e2e_latency_ms) in &checkpoint_e2e_latency_samples {
-        crate::metrics::E2E_LATENCY_MS.record(*e2e_latency_ms, &metric_attributes);
-
         let mut attrs = metric_attributes.clone();
         attrs.push(KeyValue::new("checkpoint_idx", *checkpoint_idx as i64));
         crate::metrics::E2E_LATENCY_GAUGE_MS.record(*e2e_latency_ms, &attrs);

--- a/src/commands/load/mod.rs
+++ b/src/commands/load/mod.rs
@@ -1110,7 +1110,9 @@ pub(crate) async fn run(
     // If interrupted (ctrl-c), cancel both the test and the ETL pipeline.
     // Collect checkpoint E2E latency samples during the loop, then emit
     // them post-loop so they carry the final `outcome` dimension.
-    let mut checkpoint_e2e_latency_samples: Vec<f64> = Vec::new();
+    // (checkpoint_idx, e2e_latency_ms) per converged mutation checkpoint. The
+    // index is carried so each sample can be emitted as a distinct gauge series.
+    let mut checkpoint_e2e_latency_samples: Vec<(usize, f64)> = Vec::new();
 
     let run_outcome: Option<RunOutcome> = loop {
         tokio::select! {
@@ -1160,7 +1162,7 @@ pub(crate) async fn run(
 
                                     match result {
                                         CheckpointValidationResult::Converged { e2e_latency_ms } => {
-                                            checkpoint_e2e_latency_samples.push(e2e_latency_ms);
+                                            checkpoint_e2e_latency_samples.push((checkpoint_idx, e2e_latency_ms));
                                         }
                                         CheckpointValidationResult::Interrupted => {
                                             tracing::error!("Interrupt received during checkpoint validation, stopping...");
@@ -1244,7 +1246,7 @@ pub(crate) async fn run(
 
                                     match result {
                                         CheckpointValidationResult::Converged { e2e_latency_ms } => {
-                                            checkpoint_e2e_latency_samples.push(e2e_latency_ms);
+                                            checkpoint_e2e_latency_samples.push((checkpoint_idx, e2e_latency_ms));
                                         }
                                         CheckpointValidationResult::Interrupted => {
                                             tracing::error!("Interrupt received during final checkpoint validation, stopping...");
@@ -1349,8 +1351,12 @@ pub(crate) async fn run(
     metric_attributes.push(KeyValue::new("outcome", outcome.as_str()));
 
     // Record deferred metrics now that outcome is available.
-    for sample in &checkpoint_e2e_latency_samples {
-        crate::metrics::E2E_LATENCY_MS.record(*sample, &metric_attributes);
+    for (checkpoint_idx, e2e_latency_ms) in &checkpoint_e2e_latency_samples {
+        crate::metrics::E2E_LATENCY_MS.record(*e2e_latency_ms, &metric_attributes);
+
+        let mut attrs = metric_attributes.clone();
+        attrs.push(KeyValue::new("checkpoint_idx", *checkpoint_idx as i64));
+        crate::metrics::E2E_LATENCY_GAUGE_MS.record(*e2e_latency_ms, &attrs);
     }
 
     test.get_query_durations().statistical_set()?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -144,14 +144,6 @@ pub static EFFICIENCY_QUERIES_PER_CORE: LazyLock<Gauge<f64>> = LazyLock::new(|| 
 
 // --- E2E Latency ---
 
-pub static E2E_LATENCY_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
-    meter()
-        .f64_histogram("e2e_latency_ms")
-        .with_description("End-to-end latency from event creation to the event being queryable.")
-        .with_unit("ms")
-        .build()
-});
-
 // Per-checkpoint convergence latency, recorded once per converged mutation
 // checkpoint with a `checkpoint_idx` attribute so each sample is a distinct
 // gauge series and survives last-value aggregation (a histogram only exports

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -151,3 +151,17 @@ pub static E2E_LATENCY_MS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
         .with_unit("ms")
         .build()
 });
+
+// Per-checkpoint convergence latency, recorded once per converged mutation
+// checkpoint with a `checkpoint_idx` attribute so each sample is a distinct
+// gauge series and survives last-value aggregation (a histogram only exports
+// `_sum`/`_count`/buckets, from which a true per-checkpoint value or exact
+// percentile cannot be recovered). Aggregate in the dashboard by grouping over
+// the desired population (e.g. `run_id` or adapter) and applying `quantile`.
+pub static E2E_LATENCY_GAUGE_MS: LazyLock<Gauge<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_gauge("e2e_latency_gauge_ms")
+        .with_description("Per-checkpoint end-to-end convergence latency (CDC replication + apply lag), tagged with checkpoint_idx.")
+        .with_unit("ms")
+        .build()
+});


### PR DESCRIPTION
## Problem

`e2e_latency_ms` is an OTel `Histogram` recorded once per checkpoint. When exported to InfluxDB, the histogram lands as a row of separate fields — one per bucket boundary, plus `count` and `sum`:
| Time | 0 | 10 | 100 | 1000 | 10000 | +Inf | count | sum |
|---|---|---|---|---|---|---|---|---|
| 2026-06-19 14:30:06 | 0 | 0 | 0 | 0 | 1 | 2 | 3 | 24279 |

The query will attempt to find p99 from these values - and returns `24279` which is a sum of all checkpoint latencies.

## Change

  - Add a new `e2e_latency_gauge_ms` gauge, recorded per converged checkpoint with a `checkpoint_idx` attribute so each sample is a distinct series 
  - Carry `checkpoint_idx` alongside each latency sample (`Vec<(usize, f64)>`) so it can be attached at emit time.
  
New query:
```fluxql
from(bucket: "benchmarks-telemetry")
    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
    |> filter(fn: (r) => r["type"] == "spicebench")
    |> filter(fn: (r) => r["_measurement"] == "e2e_latency_gauge_ms")
    |> filter(fn: (r) => r["scale_factor"] == "1")
    |> filter(fn: (r) => r["adapter_name"] == "mongodb-streams-cayenne")
    |> filter(fn: (r) => r["outcome"] == "success")
    |> filter(fn: (r) => r["etl_type"] == "changes")
    |> toFloat()
    |> map(fn: (r) => ({ r with legend: r["adapter_name"] + " - " + r["scenario"] }))
    |> group(columns: ["legend"])                          // collapse across checkpoint_idx + run_id
    |> quantile(q: 0.99, method: "exact_selector")         // exact p99 over the raw samples
    |> keep(columns: ["_value", "legend"])
```
